### PR TITLE
Added BASE-IAM-URI option

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -45,6 +45,8 @@ const (
 	filterFlag                     = "filter"
 	baseURIFlag                    = "base-uri"
 	baseURIFlagUsage               = "The base system URI"
+	baseIAMURIFlag                 = "base-iam-uri"
+	baseIAMURIFlagUsage            = "The base system IAM URI"
 	astTokenFlag                   = "ast-token"
 	astTokenUsage                  = "The token to login to AST with"
 	queriesRepoNameFlag            = "name"
@@ -89,6 +91,7 @@ func NewAstCLI(
 	rootCmd.PersistentFlags().String(astAuthenticationPathFlag, "", astAuthenticationPathFlagUsage)
 	rootCmd.PersistentFlags().Bool(insecureFlag, false, insecureFlagUsage)
 	rootCmd.PersistentFlags().String(baseURIFlag, params.BaseURI, baseURIFlagUsage)
+	rootCmd.PersistentFlags().String(baseIAMURIFlag, params.BaseIAMURI, baseIAMURIFlagUsage)
 	rootCmd.PersistentFlags().String(profileFlag, params.Profile, profileFlagUsage)
 	rootCmd.PersistentFlags().String(astTokenFlag, params.BaseURI, astTokenUsage)
 
@@ -99,6 +102,7 @@ func NewAstCLI(
 	_ = viper.BindPFlag(params.AccessKeySecretConfigKey, rootCmd.PersistentFlags().Lookup(accessKeySecretFlag))
 	_ = viper.BindPFlag(params.AstAuthenticationPathConfigKey, rootCmd.PersistentFlags().Lookup(astAuthenticationPathFlag))
 	_ = viper.BindPFlag(params.BaseURIKey, rootCmd.PersistentFlags().Lookup(baseURIFlag))
+	_ = viper.BindPFlag(params.BaseIAMURIKey, rootCmd.PersistentFlags().Lookup(baseIAMURIFlag))
 	_ = viper.BindPFlag(params.AstTokenKey, rootCmd.PersistentFlags().Lookup(astTokenFlag))
 	// Key here is the actual flag since it doesn't use an environment variable
 	_ = viper.BindPFlag(verboseFlag, rootCmd.PersistentFlags().Lookup(verboseFlag))

--- a/internal/params/binds.go
+++ b/internal/params/binds.go
@@ -6,6 +6,7 @@ var EnvVarsBinds = []struct {
 	Default string
 }{
 	{BaseURIKey, BaseURIEnv, "http://127.0.0.1:80"},
+	{BaseIAMURIKey, BaseIAMURIEnv, ""},
 	{AstUsernameKey, AstUsernameEnv, ""},
 	{AstPasswordKey, AstPasswordEnv, ""},
 	{AstTokenKey, AstTokenEnv, ""},

--- a/internal/params/envs.go
+++ b/internal/params/envs.go
@@ -2,6 +2,7 @@ package params
 
 const (
 	BaseURIEnv                          = "CX_BASE_URI"
+	BaseIAMURIEnv                       = "CX_BASE_IAM_URI"
 	AstUsernameEnv                      = "CX_AST_USERNAME"
 	AstPasswordEnv                      = "CX_AST_PASSWORD"
 	AstTokenEnv                         = "CX_AST_TOKEN"

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -31,5 +31,6 @@ const (
 	SastALlInOne = "SAST_ALL_IN_ONE"
 	Profile      = "default"
 	BaseURI      = "127.0.0.1:80"
+	BaseIAMURI   = ""
 	AstToken     = ""
 )

--- a/internal/params/keys.go
+++ b/internal/params/keys.go
@@ -4,6 +4,7 @@ import "strings"
 
 var (
 	BaseURIKey                          = strings.ToLower(BaseURIEnv)
+	BaseIAMURIKey                       = strings.ToLower(BaseIAMURIEnv)
 	AstUsernameKey                      = strings.ToLower(AstUsernameEnv)
 	AstPasswordKey                      = strings.ToLower(AstPasswordEnv)
 	AstTokenKey                         = strings.ToLower(AstTokenEnv)

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -108,6 +108,14 @@ func GetURL(path string) string {
 	return fmt.Sprintf("%s/%s", viper.GetString(commonParams.BaseURIKey), path)
 }
 
+func GetAuthURL(path string) string {
+	if viper.GetString(commonParams.BaseIAMURIKey) != "" {
+		return fmt.Sprintf("%s/%s", viper.GetString(commonParams.BaseIAMURIKey), path)
+	} else {
+		return ""
+	}
+}
+
 func SendHTTPRequestWithQueryParams(method, path string, params map[string]string,
 	body io.Reader, timeout uint) (*http.Response, error) {
 	client := getClient(timeout)
@@ -138,8 +146,10 @@ func getAuthURI() (string, error) {
 	if authPath == "" {
 		return "", errors.Errorf(fmt.Sprintf(failedToAuth, "authentication path"))
 	}
-
-	authURI := GetURL(authPath)
+	authURI := GetAuthURL(authPath)
+	if authURI == "" {
+		authURI = GetURL(authPath)
+	}
 	authURL, err := url.Parse(authURI)
 	if err != nil {
 		return "", errors.Wrap(err, "authentication URI is not in a correct format")


### PR DESCRIPTION
Added CLI option to specify --base-iam-uri as an alternative to --base-uri. If the --base-iam-uri parameter is specified it will overide --base-uri to when performing authentication requests.