### PR TITLE
Fixes panic when creating a scan with a project named "test"

### DIFF
--- a/internal/commands/project.go
+++ b/internal/commands/project.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	failedCreatingProj = "Failed creating a project"
+	FailedCreatingProj = "Failed creating a project"
 	failedGettingProj  = "Failed getting a project"
 	failedDeletingProj = "Failed deleting a project"
 )
@@ -190,7 +190,7 @@ func runCreateProjectCommand(projectsWrapper wrappers.ProjectsWrapper) func(cmd 
 		// Try to parse to a project model in order to manipulate the request payload
 		err = json.Unmarshal(input, &projModel)
 		if err != nil {
-			return errors.Wrapf(err, "%s: Input in bad format", failedCreatingProj)
+			return errors.Wrapf(err, "%s: Input in bad format", FailedCreatingProj)
 		}
 		var payload []byte
 		payload, _ = json.Marshal(projModel)
@@ -198,16 +198,16 @@ func runCreateProjectCommand(projectsWrapper wrappers.ProjectsWrapper) func(cmd 
 
 		projResponseModel, errorModel, err = projectsWrapper.Create(&projModel)
 		if err != nil {
-			return errors.Wrapf(err, "%s", failedCreatingProj)
+			return errors.Wrapf(err, "%s", FailedCreatingProj)
 		}
 
 		// Checking the response
 		if errorModel != nil {
-			return errors.Errorf("%s: CODE: %d, %s\n", failedCreatingProj, errorModel.Code, errorModel.Message)
+			return errors.Errorf(ErrorCodeFormat, FailedCreatingProj, errorModel.Code, errorModel.Message)
 		} else if projResponseModel != nil {
 			err = printByFormat(cmd, toProjectView(*projResponseModel))
 			if err != nil {
-				return errors.Wrapf(err, "%s", failedCreatingProj)
+				return errors.Wrapf(err, "%s", FailedCreatingProj)
 			}
 		}
 		return nil
@@ -230,7 +230,7 @@ func runListProjectsCommand(projectsWrapper wrappers.ProjectsWrapper) func(cmd *
 		}
 		// Checking the response
 		if errorModel != nil {
-			return errors.Errorf("%s: CODE: %d, %s\n", failedGettingAll, errorModel.Code, errorModel.Message)
+			return errors.Errorf(ErrorCodeFormat, failedGettingAll, errorModel.Code, errorModel.Message)
 		} else if allProjectsModel != nil && allProjectsModel.Projects != nil {
 			err = printByFormat(cmd, toProjectViews(allProjectsModel.Projects))
 			if err != nil {
@@ -281,7 +281,7 @@ func runDeleteProjectCommand(projectsWrapper wrappers.ProjectsWrapper) func(cmd 
 		}
 		// Checking the response
 		if errorModel != nil {
-			return errors.Errorf("%s: CODE: %d, %s\n", failedDeletingProj, errorModel.Code, errorModel.Message)
+			return errors.Errorf(ErrorCodeFormat, failedDeletingProj, errorModel.Code, errorModel.Message)
 		}
 		return nil
 	}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -16,6 +16,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+const ErrorCodeFormat = "%s: CODE: %d, %s\n"
+
 // NewAstCLI Return an AST CLI root command to execute
 func NewAstCLI(
 	scansWrapper wrappers.ScansWrapper,

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -342,8 +342,11 @@ func createProject(projectName string) (string, error) {
 	projModel.Tags = make(map[string]string)
 	projects := viper.GetString(commonParams.ProjectsPathKey)
 	projectsWrapper := wrappers.NewHTTPProjectsWrapper(projects)
-	resp, _, err := projectsWrapper.Create(&projModel)
+	resp, errorModel, err := projectsWrapper.Create(&projModel)
 	projectID := ""
+	if errorModel != nil {
+		err = errors.Errorf(ErrorCodeFormat, FailedCreatingProj, errorModel.Code, errorModel.Message)
+	}
 	if err == nil {
 		projectID = resp.ID
 	}
@@ -766,7 +769,7 @@ func runCreateScanCommand(
 		}
 		// Checking the response
 		if errorModel != nil {
-			return errors.Errorf("%s: CODE: %d, %s\n", failedCreating, errorModel.Code, errorModel.Message)
+			return errors.Errorf(ErrorCodeFormat, failedCreating, errorModel.Code, errorModel.Message)
 		} else if scanResponseModel != nil {
 			err = printByFormat(cmd, toScanView(scanResponseModel))
 			if err != nil {
@@ -955,7 +958,7 @@ func runListScansCommand(scansWrapper wrappers.ScansWrapper) func(cmd *cobra.Com
 		}
 		// Checking the response
 		if errorModel != nil {
-			return errors.Errorf("%s: CODE: %d, %s\n", failedGettingAll, errorModel.Code, errorModel.Message)
+			return errors.Errorf(ErrorCodeFormat, failedGettingAll, errorModel.Code, errorModel.Message)
 		} else if allScansModel != nil && allScansModel.Scans != nil {
 			err = printByFormat(cmd, toScanViews(allScansModel.Scans))
 			if err != nil {
@@ -1032,7 +1035,7 @@ func runDeleteScanCommand(scansWrapper wrappers.ScansWrapper) func(cmd *cobra.Co
 
 			// Checking the response
 			if errorModel != nil {
-				return errors.Errorf("%s: CODE: %d, %s\n", failedDeleting, errorModel.Code, errorModel.Message)
+				return errors.Errorf(ErrorCodeFormat, failedDeleting, errorModel.Code, errorModel.Message)
 			}
 		}
 
@@ -1054,7 +1057,7 @@ func runCancelScanCommand(scansWrapper wrappers.ScansWrapper) func(cmd *cobra.Co
 
 			// Checking the response
 			if errorModel != nil {
-				return errors.Errorf("%s: CODE: %d, %s\n", failedCanceling, errorModel.Code, errorModel.Message)
+				return errors.Errorf(ErrorCodeFormat, failedCanceling, errorModel.Code, errorModel.Message)
 			}
 		}
 


### PR DESCRIPTION
- handle the error model when calling projectsWrapper.Create
