### PR TITLE
Renaming nowait flag to async

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -285,7 +285,7 @@ func scanCreateSubCommand(
 		},
 		RunE: runCreateScanCommand(scansWrapper, uploadsWrapper, resultsWrapper, projectsWrapper),
 	}
-	createScanCmd.PersistentFlags().BoolP(commonParams.WaitFlag, "", true, "Wait for scan completion (default true)")
+	createScanCmd.PersistentFlags().BoolP(commonParams.WaitFlag, "", true, "Wait for scan completion")
 	createScanCmd.PersistentFlags().IntP(commonParams.WaitDelayFlag, "", commonParams.WaitDelayDefault, "Polling wait time in seconds")
 	createScanCmd.PersistentFlags().StringP(
 		commonParams.SourcesFlag,

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -285,7 +285,7 @@ func scanCreateSubCommand(
 		},
 		RunE: runCreateScanCommand(scansWrapper, uploadsWrapper, resultsWrapper, projectsWrapper),
 	}
-	createScanCmd.PersistentFlags().BoolP(commonParams.WaitFlag, "", true, "Wait for scan completion")
+	createScanCmd.PersistentFlags().BoolP(commonParams.AsyncFlag, "", false, "Wait for scan completion")
 	createScanCmd.PersistentFlags().IntP(commonParams.WaitDelayFlag, "", commonParams.WaitDelayDefault, "Polling wait time in seconds")
 	createScanCmd.PersistentFlags().StringP(
 		commonParams.SourcesFlag,
@@ -795,8 +795,8 @@ func runCreateScanCommand(
 		}
 
 		// Wait until the scan is done: Queued, Running
-		WaitFlag, _ := cmd.Flags().GetBool(commonParams.WaitFlag)
-		if WaitFlag {
+		AsyncFlag, _ := cmd.Flags().GetBool(commonParams.AsyncFlag)
+		if !AsyncFlag {
 			waitDelay, _ := cmd.Flags().GetInt(commonParams.WaitDelayFlag)
 			return handleWait(cmd, scanResponseModel, waitDelay, scansWrapper, resultsWrapper)
 		}

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -285,7 +285,7 @@ func scanCreateSubCommand(
 		},
 		RunE: runCreateScanCommand(scansWrapper, uploadsWrapper, resultsWrapper, projectsWrapper),
 	}
-	createScanCmd.PersistentFlags().BoolP(commonParams.WaitFlag, "", false, "Wait for scan completion (default true)")
+	createScanCmd.PersistentFlags().BoolP(commonParams.WaitFlag, "", true, "Wait for scan completion (default true)")
 	createScanCmd.PersistentFlags().IntP(commonParams.WaitDelayFlag, "", commonParams.WaitDelayDefault, "Polling wait time in seconds")
 	createScanCmd.PersistentFlags().StringP(
 		commonParams.SourcesFlag,
@@ -795,8 +795,8 @@ func runCreateScanCommand(
 		}
 
 		// Wait until the scan is done: Queued, Running
-		noWaitFlag, _ := cmd.Flags().GetBool(commonParams.WaitFlag)
-		if !noWaitFlag {
+		WaitFlag, _ := cmd.Flags().GetBool(commonParams.WaitFlag)
+		if WaitFlag {
 			waitDelay, _ := cmd.Flags().GetInt(commonParams.WaitDelayFlag)
 			return handleWait(cmd, scanResponseModel, waitDelay, scansWrapper, resultsWrapper)
 		}

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -285,7 +285,7 @@ func scanCreateSubCommand(
 		},
 		RunE: runCreateScanCommand(scansWrapper, uploadsWrapper, resultsWrapper, projectsWrapper),
 	}
-	createScanCmd.PersistentFlags().BoolP(commonParams.AsyncFlag, "", false, "Wait for scan completion")
+	createScanCmd.PersistentFlags().BoolP(commonParams.AsyncFlag, "", false, "Do not wait for scan completion")
 	createScanCmd.PersistentFlags().IntP(commonParams.WaitDelayFlag, "", commonParams.WaitDelayDefault, "Polling wait time in seconds")
 	createScanCmd.PersistentFlags().StringP(
 		commonParams.SourcesFlag,

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -11,7 +11,7 @@ const (
 	SourcesFlagSh            = "s"
 	TenantFlag               = "tenant"
 	TenantFlagUsage          = "Checkmarx tenant"
-	WaitFlag                 = "nowait"
+	WaitFlag                 = "wait"
 	WaitDelayFlag            = "wait-delay"
 	SourceDirFilterFlag      = "file-filter"
 	SourceDirFilterFlagSh    = "f"

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -11,7 +11,7 @@ const (
 	SourcesFlagSh            = "s"
 	TenantFlag               = "tenant"
 	TenantFlagUsage          = "Checkmarx tenant"
-	WaitFlag                 = "wait"
+	AsyncFlag                = "async"
 	WaitDelayFlag            = "wait-delay"
 	SourceDirFilterFlag      = "file-filter"
 	SourceDirFilterFlagSh    = "f"

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -184,11 +184,11 @@ func createScan(t *testing.T, source string, tags map[string]string) (string, st
 }
 
 func createScanNoWait(t *testing.T, source string, tags map[string]string) (string, string) {
-	return executeCreateScan(t, append(getCreateArgs(source, tags), "--nowait"))
+	return executeCreateScan(t, append(getCreateArgs(source, tags), "--wait=false"))
 }
 
 func createScanNoWaitWithResolver(t *testing.T, source string, tags map[string]string) (string, string) {
-	return executeCreateScan(t, append(getCreateArgs(source, tags), "--nowait", "--sca-resolver", "nop"))
+	return executeCreateScan(t, append(getCreateArgs(source, tags), "--wait=false", "--sca-resolver", "nop"))
 }
 
 func createScanIncremental(t *testing.T, source string, name string, tags map[string]string) (string, string) {

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -184,11 +184,11 @@ func createScan(t *testing.T, source string, tags map[string]string) (string, st
 }
 
 func createScanNoWait(t *testing.T, source string, tags map[string]string) (string, string) {
-	return executeCreateScan(t, append(getCreateArgs(source, tags), "--wait=false"))
+	return executeCreateScan(t, append(getCreateArgs(source, tags), flag(params.AsyncFlag)))
 }
 
 func createScanNoWaitWithResolver(t *testing.T, source string, tags map[string]string) (string, string) {
-	return executeCreateScan(t, append(getCreateArgs(source, tags), "--wait=false", "--sca-resolver", "nop"))
+	return executeCreateScan(t, append(getCreateArgs(source, tags), flag(params.AsyncFlag), "--sca-resolver", "nop"))
 }
 
 func createScanIncremental(t *testing.T, source string, name string, tags map[string]string) (string, string) {


### PR DESCRIPTION
In sequence of the AST-5650 task, the nowait flag was renamed to wait. The default behaviour is waiting for the scan to complete.