### PR TITLE
AST-8492 Timeout

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1015,7 +1015,7 @@ func setupProjectHandler(
 func handleWait(
 	cmd *cobra.Command,
 	scanResponseModel *wrappers.ScanResponseModel,
-	waitDelay int,
+	waitDelay,
 	timeoutMinutes int,
 	scansWrapper wrappers.ScansWrapper,
 	resultsWrapper wrappers.ResultsWrapper,
@@ -1128,7 +1128,7 @@ func getSummaryThresholdMap(resultsWrapper wrappers.ResultsWrapper, scanID strin
 
 func waitForScanCompletion(
 	scanResponseModel *wrappers.ScanResponseModel,
-	waitDelay int,
+	waitDelay,
 	timeoutMinutes int,
 	scansWrapper wrappers.ScansWrapper,
 ) error {
@@ -1144,7 +1144,7 @@ func waitForScanCompletion(
 			break
 		}
 		if timeoutMinutes > 0 && time.Now().After(timeout) {
-			log.Println("Cancelling scan", scanResponseModel.ID)
+			log.Println("Canceling scan", scanResponseModel.ID)
 			errorModel, err := scansWrapper.Cancel(scanResponseModel.ID)
 			if err != nil {
 				return errors.Wrapf(err, "%s\n", failedCanceling)

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -306,6 +306,11 @@ func scanCreateSubCommand(
 		commonParams.WaitDelayDefault,
 		"Polling wait time in seconds",
 	)
+	createScanCmd.PersistentFlags().Int(
+		commonParams.ScanTimeoutFlag,
+		0,
+		"Cancel the scan and fail after the timeout in minutes",
+	)
 	createScanCmd.PersistentFlags().StringP(
 		commonParams.SourcesFlag,
 		commonParams.SourcesFlagSh,
@@ -918,7 +923,8 @@ func runCreateScanCommand(
 		AsyncFlag, _ := cmd.Flags().GetBool(commonParams.AsyncFlag)
 		if !AsyncFlag {
 			waitDelay, _ := cmd.Flags().GetInt(commonParams.WaitDelayFlag)
-			err := handleWait(cmd, scanResponseModel, waitDelay, scansWrapper, resultsWrapper)
+			timeoutMinutes, _ := cmd.Flags().GetInt(commonParams.TimeoutFlag)
+			err := handleWait(cmd, scanResponseModel, waitDelay, timeoutMinutes, scansWrapper, resultsWrapper)
 			if err != nil {
 				return err
 			}
@@ -1010,10 +1016,11 @@ func handleWait(
 	cmd *cobra.Command,
 	scanResponseModel *wrappers.ScanResponseModel,
 	waitDelay int,
+	timeoutMinutes int,
 	scansWrapper wrappers.ScansWrapper,
 	resultsWrapper wrappers.ResultsWrapper,
 ) error {
-	err := waitForScanCompletion(scanResponseModel, waitDelay, scansWrapper)
+	err := waitForScanCompletion(scanResponseModel, waitDelay, timeoutMinutes, scansWrapper)
 	if err != nil {
 		verboseFlag, _ := cmd.Flags().GetBool(commonParams.DebugFlag)
 		if verboseFlag {
@@ -1122,9 +1129,11 @@ func getSummaryThresholdMap(resultsWrapper wrappers.ResultsWrapper, scanID strin
 func waitForScanCompletion(
 	scanResponseModel *wrappers.ScanResponseModel,
 	waitDelay int,
+	timeoutMinutes int,
 	scansWrapper wrappers.ScansWrapper,
 ) error {
-	log.Println("wait for scan to complete", scanResponseModel.ID, scanResponseModel.Status)
+	log.Println("Wait for scan to complete", scanResponseModel.ID, scanResponseModel.Status)
+	timeout := time.Now().Add(time.Duration(timeoutMinutes) * time.Minute)
 	time.Sleep(time.Duration(waitDelay) * time.Second)
 	for {
 		running, err := isScanRunning(scansWrapper, scanResponseModel.ID)
@@ -1133,6 +1142,17 @@ func waitForScanCompletion(
 		}
 		if !running {
 			break
+		}
+		if timeoutMinutes > 0 && time.Now().After(timeout) {
+			log.Println("Cancelling scan", scanResponseModel.ID)
+			errorModel, err := scansWrapper.Cancel(scanResponseModel.ID)
+			if err != nil {
+				return errors.Wrapf(err, "%s\n", failedCanceling)
+			}
+			if errorModel != nil {
+				return errors.Errorf(ErrorCodeFormat, failedCanceling, errorModel.Code, errorModel.Message)
+			}
+			return errors.Errorf("Timeout of %d minute(s) for scan reached", timeoutMinutes)
 		}
 		time.Sleep(time.Duration(waitDelay) * time.Second)
 	}
@@ -1273,7 +1293,6 @@ func runCancelScanCommand(scansWrapper wrappers.ScansWrapper) func(cmd *cobra.Co
 			if err != nil {
 				return errors.Wrapf(err, "%s\n", failedCanceling)
 			}
-
 			// Checking the response
 			if errorModel != nil {
 				return errors.Errorf(ErrorCodeFormat, failedCanceling, errorModel.Code, errorModel.Message)

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -923,7 +923,7 @@ func runCreateScanCommand(
 		AsyncFlag, _ := cmd.Flags().GetBool(commonParams.AsyncFlag)
 		if !AsyncFlag {
 			waitDelay, _ := cmd.Flags().GetInt(commonParams.WaitDelayFlag)
-			timeoutMinutes, _ := cmd.Flags().GetInt(commonParams.TimeoutFlag)
+			timeoutMinutes, _ := cmd.Flags().GetInt(commonParams.ScanTimeoutFlag)
 			err := handleWait(cmd, scanResponseModel, waitDelay, timeoutMinutes, scansWrapper, resultsWrapper)
 			if err != nil {
 				return err

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -19,7 +19,7 @@ const (
 	TenantFlagUsage          = "Checkmarx tenant"
 	AsyncFlag                = "async"
 	WaitDelayFlag            = "wait-delay"
-	ScanTimeoutFlag          = "timeout"
+	ScanTimeoutFlag          = "scan-timeout"
 	SourceDirFilterFlag      = "file-filter"
 	SourceDirFilterFlagSh    = "f"
 	IncludeFilterFlag        = "file-include"

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -19,6 +19,7 @@ const (
 	TenantFlagUsage          = "Checkmarx tenant"
 	AsyncFlag                = "async"
 	WaitDelayFlag            = "wait-delay"
+	ScanTimeoutFlag          = "timeout"
 	SourceDirFilterFlag      = "file-filter"
 	SourceDirFilterFlagSh    = "f"
 	IncludeFilterFlag        = "file-include"

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -187,7 +187,7 @@ func TestScanTimeout(t *testing.T) {
 		flag(params.ScanTypes), "sast",
 		flag(params.BranchFlag), "develop",
 		flag(params.FormatFlag), util.FormatJSON,
-		flag(params.TimeoutFlag), "1",
+		flag(params.ScanTimeoutFlag), "1",
 	}
 
 	cmd, buffer := createRedirectedTestCommand(t)


### PR DESCRIPTION
- Add timeout flag to cancel the scan in minutes

### Description

Add timeout mechanism to the CLI that cancels the scan and returns an error code if the timeout is reached.

### References

https://checkmarx.atlassian.net/browse/AST-8492

### Testing

Added a test that performs a slow scan with a 1 minute timeout and asserts the error and the cancelled state.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used