### PR TITLE
Modified default folder permissions for (cx configure) command

### DIFF
--- a/internal/wrappers/configuration/configuration.go
+++ b/internal/wrappers/configuration/configuration.go
@@ -14,7 +14,7 @@ import (
 
 const configDirName = "/.checkmarx"
 const obfuscateLimit = 4
-const homeDirectoryPermissions = 0600
+const homeDirectoryPermissions = 0700
 
 func PromptConfiguration() {
 	reader := bufio.NewReader(os.Stdin)


### PR DESCRIPTION
Modified default folder permissions for (cx configure) command to allow proper creation of profile configuration on macs. The permissions were changed from 600 to 700.