### PR TITLE
AST-5288 auth register should require role

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Checkmarx AST CLI Action
-        uses: checkmarxDev/ast-github-action@master
+        uses: checkmarx/ast-github-action@main
         with:
           project_name: astcli-ci
           base_uri: ${{ secrets.BASE_URI }}

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -173,7 +173,7 @@ func runRegister(authWrapper wrappers.AuthWrapper) func(cmd *cobra.Command, args
 }
 
 func validateRoles(roles []string) error {
-	if roles == nil || len(roles) == 0 {
+	if len(roles) == 0 {
 		return errors.Errorf(pleaseProvideFlag, failedCreatingClient, params.ClientRolesFlag)
 	}
 	for _, role := range roles {

--- a/internal/commands/auth_test.go
+++ b/internal/commands/auth_test.go
@@ -3,6 +3,7 @@
 package commands
 
 import (
+	"strings"
 	"testing"
 
 	"gotest.tools/assert"
@@ -17,11 +18,17 @@ func TestAuthNoSub(t *testing.T) {
 }
 
 func TestRunCreateOath2ClientCommand(t *testing.T) {
-	args := []string{"auth", "register", "--username", "username", "--password", "password"}
+	args := []string{
+		"auth",
+		"register",
+		"--username",
+		"username",
+		"--password",
+		"password",
+		"--roles",
+		strings.Join(RoleSlice, ","),
+	}
 	execCmdNilAssertion(t, args...)
-
-	// Create Oath2Client with roles
-	execCmdNilAssertion(t, append(args, "--roles", "admin,user")...)
 }
 
 func TestRunCreateOath2ClientCommandInvalid(t *testing.T) {
@@ -29,6 +36,21 @@ func TestRunCreateOath2ClientCommandInvalid(t *testing.T) {
 }
 
 func TestRunCreateOath2ClientCommandNoPassword(t *testing.T) {
-	err := execCmdNotNilAssertion(t, "auth", "register", "--username", "username")
+	err := execCmdNotNilAssertion(
+		t, "auth", "register", "--username", "username", "--roles", strings.Join(RoleSlice, ","),
+	)
 	assert.Equal(t, err.Error(), "failed creating client: Please provide password flag")
+}
+
+func TestRunCreateOath2ClientCommandNoRoles(t *testing.T) {
+	err := execCmdNotNilAssertion(
+		t,
+		"auth",
+		"register",
+		"--username",
+		"username",
+		"--password",
+		"password",
+	)
+	assert.Equal(t, err.Error(), "required flag(s) \"roles\" not set")
 }


### PR DESCRIPTION
### Description

Make flag roles required in auth register
- Make flag -r, --roles required
- Add possible values to usage
- Error out if roles not in the possible values are provided

### References

https://checkmarx.atlassian.net/browse/AST-5288

### Testing

- Rename TestAuthRegisterWithEmptyUsernameOrPassword to TestAuthRegisterWithEmptyParameters
- Add call in TestAuthRegisterWithEmptyParameters with missing --roles
- Add roles to TestAuthRegister
- Add unit test

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used