### PR TITLE
AST-9551 CLI | Create user-count command for Github SCM

### DIFF
--- a/internal/commands/util/usercount/github.go
+++ b/internal/commands/util/usercount/github.go
@@ -75,6 +75,8 @@ func createRunGitHubUserCountFunc(gitHubWrapper wrappers.GitHubWrapper) func(cmd
 		var totalCommits []wrappers.Commit
 		var views []RepositoryView
 
+		_ = viper.BindPFlag(params.SCMTokenFlag, cmd.Flags().Lookup(params.SCMTokenFlag))
+
 		if len(repos) > 0 {
 			totalCommits, views, err = collectFromRepos(gitHubWrapper)
 		} else {

--- a/internal/commands/util/usercount/github.go
+++ b/internal/commands/util/usercount/github.go
@@ -1,8 +1,6 @@
 package usercount
 
 import (
-	"strings"
-
 	"github.com/checkmarx/ast-cli/internal/commands/util/printer"
 	"github.com/checkmarx/ast-cli/internal/params"
 	"github.com/checkmarx/ast-cli/internal/wrappers"
@@ -28,7 +26,7 @@ const (
 	missingArgs    = "provide at least one repository or organization"
 	missingOrg     = "an organization is required for your repositories"
 	tooManyOrgs    = "a single organization should be provided for specific repositories"
-	noReplySuffix  = "@users.noreply.github.com"
+	botType        = "Bot"
 )
 
 var (
@@ -72,7 +70,7 @@ func createRunGitHubUserCountFunc(gitHubWrapper wrappers.GitHubWrapper) func(cmd
 	return func(cmd *cobra.Command, args []string) error {
 		var err error
 
-		var totalCommits []wrappers.Commit
+		var totalCommits []wrappers.CommitRoot
 		var views []RepositoryView
 
 		_ = viper.BindPFlag(params.SCMTokenFlag, cmd.Flags().Lookup(params.SCMTokenFlag))
@@ -102,8 +100,8 @@ func createRunGitHubUserCountFunc(gitHubWrapper wrappers.GitHubWrapper) func(cmd
 	}
 }
 
-func collectFromRepos(gitHubWrapper wrappers.GitHubWrapper) ([]wrappers.Commit, []RepositoryView, error) {
-	var totalCommits []wrappers.Commit
+func collectFromRepos(gitHubWrapper wrappers.GitHubWrapper) ([]wrappers.CommitRoot, []RepositoryView, error) {
+	var totalCommits []wrappers.CommitRoot
 	var views []RepositoryView
 	for _, repo := range repos {
 		repository, err := gitHubWrapper.GetRepository(orgs[0], repo)
@@ -131,8 +129,8 @@ func collectFromRepos(gitHubWrapper wrappers.GitHubWrapper) ([]wrappers.Commit, 
 	return totalCommits, views, nil
 }
 
-func collectFromOrgs(gitHubWrapper wrappers.GitHubWrapper) ([]wrappers.Commit, []RepositoryView, error) {
-	var totalCommits []wrappers.Commit
+func collectFromOrgs(gitHubWrapper wrappers.GitHubWrapper) ([]wrappers.CommitRoot, []RepositoryView, error) {
+	var totalCommits []wrappers.CommitRoot
 	var views []RepositoryView
 
 	for _, org := range orgs {
@@ -168,13 +166,17 @@ func collectFromOrgs(gitHubWrapper wrappers.GitHubWrapper) ([]wrappers.Commit, [
 	return totalCommits, views, nil
 }
 
-func getUniqueContributors(commits []wrappers.Commit) uint64 {
+func getUniqueContributors(commits []wrappers.CommitRoot) uint64 {
 	var contributors = map[string]bool{}
 	for _, commit := range commits {
-		name := commit.CommitData.Author.Name
-		if !contributors[name] && !strings.HasSuffix(commit.CommitData.Author.Email, noReplySuffix) {
+		name := commit.Commit.CommitAuthor.Name
+		if !contributors[name] && isNotBot(commit) {
 			contributors[name] = true
 		}
 	}
 	return uint64(len(contributors))
+}
+
+func isNotBot(commit wrappers.CommitRoot) bool {
+	return commit.Author == nil || commit.Author.Type != botType
 }

--- a/internal/commands/util/usercount/user-count.go
+++ b/internal/commands/util/usercount/user-count.go
@@ -17,8 +17,8 @@ const (
 )
 
 var (
-	token, ninetyDaysDate, format string
-	hiddenFlags                   = []string{
+	ninetyDaysDate, format string
+	hiddenFlags            = []string{
 		params.AgentFlag,
 		params.AstAPIKeyFlag,
 		params.BaseAuthURIFlag,
@@ -53,7 +53,7 @@ func NewUserCountCommand(gitHubWrapper wrappers.GitHubWrapper) *cobra.Command {
 	userCountCmd.AddCommand(newUserCountGithubCommand(gitHubWrapper))
 
 	for _, cmd := range userCountCmd.Commands() {
-		cmd.Flags().StringVar(&token, params.SCMTokenFlag, "", params.SCMTokenUsage)
+		cmd.Flags().String(params.SCMTokenFlag, "", params.SCMTokenUsage)
 		cmd.Flags().StringVar(
 			&format,
 			params.FormatFlag,

--- a/internal/wrappers/github-http.go
+++ b/internal/wrappers/github-http.go
@@ -76,9 +76,9 @@ func (g *GitHubHTTPWrapper) GetRepositories(organization Organization) ([]Reposi
 	return repositories, err
 }
 
-func (g *GitHubHTTPWrapper) GetCommits(repository Repository, queryParams map[string]string) ([]Commit, error) {
+func (g *GitHubHTTPWrapper) GetCommits(repository Repository, queryParams map[string]string) ([]CommitRoot, error) {
 	var err error
-	var commits []Commit
+	var commits []CommitRoot
 
 	commitsURL := repository.CommitsURL
 	commitsURL = commitsURL[:strings.Index(commitsURL, "{")]

--- a/internal/wrappers/github.go
+++ b/internal/wrappers/github.go
@@ -14,15 +14,20 @@ type Repository struct {
 	CommitsURL string `json:"commits_url"`
 }
 
-type Commit struct {
-	CommitData CommitData `json:"commit"`
-}
-
-type CommitData struct {
-	Author Author `json:"author"`
+type CommitRoot struct {
+	Commit Commit  `json:"commit"`
+	Author *Author `json:"author,omitempty"`
 }
 
 type Author struct {
+	Type string `json:"type"`
+}
+
+type Commit struct {
+	CommitAuthor CommitAuthor `json:"author"`
+}
+
+type CommitAuthor struct {
 	Name  string `json:"name"`
 	Email string `json:"email"`
 }
@@ -31,5 +36,5 @@ type GitHubWrapper interface {
 	GetOrganization(organizationName string) (Organization, error)
 	GetRepository(organizationName, repositoryName string) (Repository, error)
 	GetRepositories(organization Organization) ([]Repository, error)
-	GetCommits(repository Repository, queryParams map[string]string) ([]Commit, error)
+	GetCommits(repository Repository, queryParams map[string]string) ([]CommitRoot, error)
 }

--- a/internal/wrappers/mock/github-mock.go
+++ b/internal/wrappers/mock/github-mock.go
@@ -19,6 +19,6 @@ func (g GitHubMockWrapper) GetRepositories(wrappers.Organization) ([]wrappers.Re
 	return []wrappers.Repository{{}}, nil
 }
 
-func (g GitHubMockWrapper) GetCommits(wrappers.Repository, map[string]string) ([]wrappers.Commit, error) {
-	return []wrappers.Commit{}, nil
+func (g GitHubMockWrapper) GetCommits(wrappers.Repository, map[string]string) ([]wrappers.CommitRoot, error) {
+	return []wrappers.CommitRoot{}, nil
 }


### PR DESCRIPTION
### Description

when executing the github command, bind the SCMTokenFlag from the running command to viper

### References

https://checkmarx.atlassian.net/browse/AST-9551

### Testing

N/A

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used