### PR TITLE
sca-container to sca, sarif severity and triage error codes

### DIFF
--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -31,6 +31,9 @@ const (
 	lowSonar                 = "MINOR"
 	mediumSonar              = "MAJOR"
 	highSonar                = "CRITICAL"
+	infoLowSarif             = "note"
+	mediumSarif              = "warning"
+	highSarif                = "error"
 	vulnerabilitySonar       = "VULNERABILITY"
 	infoCx                   = "INFO"
 	lowCx                    = "LOW"
@@ -728,7 +731,15 @@ func findRule(ruleIds map[interface{}]bool, result *wrappers.ScanResult) *wrappe
 
 func findResult(result *wrappers.ScanResult) *wrappers.SarifScanResult {
 	var scanResult wrappers.SarifScanResult
+	// Match cx severity with sarif severity
+	level := map[string]string{
+		infoCx:   infoLowSarif,
+		lowCx:    infoLowSarif,
+		mediumCx: mediumSarif,
+		highCx:   highSarif,
+	}
 	scanResult.RuleID = fmt.Sprintf("%v", result.ScanResultData.QueryID)
+	scanResult.Level = level[result.Severity]
 	scanResult.Message.Text = result.ScanResultData.QueryName
 	scanResult.Locations = []wrappers.SarifLocation{}
 

--- a/internal/wrappers/predicates-http.go
+++ b/internal/wrappers/predicates-http.go
@@ -83,7 +83,7 @@ func (r ResultsPredicatesHTTPWrapper) PredicateSeverityAndState(predicate *Predi
 		return nil, err
 	}
 
-	PrintIfVerbose(fmt.Sprintf("Response : %s", resp.Status))
+	PrintIfVerbose(fmt.Sprintf("Response : %s ", resp.Status))
 
 	defer func() {
 		_ = resp.Body.Close()
@@ -95,6 +95,10 @@ func (r ResultsPredicatesHTTPWrapper) PredicateSeverityAndState(predicate *Predi
 	case http.StatusOK:
 		fmt.Println("Predicate updated successfully.")
 		return nil, nil
+	case http.StatusNotModified:
+		return nil, errors.Errorf("No changes to update.")
+	case http.StatusForbidden:
+		return nil, errors.Errorf("No permission to update.")
 	case http.StatusNotFound:
 		return nil, errors.Errorf("Predicate not found.")
 	default:
@@ -130,6 +134,8 @@ func handleResponseWithBody(resp *http.Response, err error) (*PredicatesCollecti
 			return responsePredicateParsingFailed(err)
 		}
 		return &model, nil, nil
+	case http.StatusForbidden:
+		return nil, nil, errors.Errorf("No permission to update.")
 	case http.StatusNotFound:
 		return nil, nil, errors.Errorf("Predicate not found.")
 	default:

--- a/internal/wrappers/results-modifier.go
+++ b/internal/wrappers/results-modifier.go
@@ -27,7 +27,7 @@ func (s *ScanResult) UnmarshalJSON(data []byte) error {
 		s.Type = params.KicsType
 	}
 
-	if s.Type == "dependency" {
+	if s.Type == "dependency" || s.Type == "sca-container" {
 		s.Type = params.ScaType
 	}
 

--- a/internal/wrappers/results-sarif.go
+++ b/internal/wrappers/results-sarif.go
@@ -36,6 +36,7 @@ type SarifDriverRule struct {
 
 type SarifScanResult struct {
 	RuleID              string                  `json:"ruleId"`
+	Level               string                  `json:"level"`
 	Message             SarifMessage            `json:"message"`
 	PartialFingerprints *SarifResultFingerprint `json:"partialFingerprints,omitempty"`
 	Locations           []SarifLocation         `json:"locations,omitempty"`


### PR DESCRIPTION
### Description

- Mapping sca-container type to sca in results;

- Fixing missing severity map between Checkmarx and sarif format severities;

- Handling new error codes for the triage commands

### References

- https://checkmarx.atlassian.net/browse/AST-11081

- https://checkmarx.atlassian.net/browse/AST-11130 

- https://checkmarx.atlassian.net/browse/AST-8903 

### Testing

- Integration and unit testing

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used