### PR TITLE
GOARCH variable for windows should be amd64

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You can download and install Go using this link: https://golang.org/doc/install
 ### Windows
 ``` powershell
 setx GOOS=windows 
-setx GOARCH=am
+setx GOARCH=amd64
 go build -o ./bin/cx.exe ./cmd
 ```
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

The install instructions for Windows says to set GOARCH=am. It should say GOARCH=amd64 like the other operating systems. There's no impact on the CLI operation.

### References

None.

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
Does not change the operation of the CLI so no testing needed.

### Checklist

- [NA] I have added documentation for new/changed functionality in this PR (if applicable).
- [NA ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [X ] All active GitHub checks for tests, formatting, and security are passing
- [X ] The correct base branch is being used