### PR TITLE
fix: report generation when thresholds fail scan fix #415

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1106,14 +1106,20 @@ func runCreateScanCommand(
 				return err
 			}
 
+			err = createReportsAfterScan(cmd, scanResponseModel.ID, scansWrapper, resultsWrapper)
+			if err != nil {
+				return err
+			}
+
 			err = applyThreshold(cmd, resultsWrapper, scanResponseModel)
 			if err != nil {
 				return err
 			}
-		}
-		err = createReportsAfterScan(cmd, scanResponseModel.ID, scansWrapper, resultsWrapper)
-		if err != nil {
-			return err
+		} else {
+			err = createReportsAfterScan(cmd, scanResponseModel.ID, scansWrapper, resultsWrapper)
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil


### PR DESCRIPTION
### Description

I think report must be generated even if scan fail because of thresholds.

### References

https://github.com/Checkmarx/ast-cli/issues/415

### Testing

Not tested yet.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used