### PR TITLE
Add base auth uri variable for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash
         env:
           CX_BASE_URI: ${{ secrets.CX_BASE_URI }}
-          CX_BASE_AUTH_URI: ${{ secrets.BASE_AUTH_URI }}
+          CX_BASE_AUTH_URI: ${{ secrets.CX_BASE_AUTH_URI }}
           CX_AST_USERNAME: ${{ secrets.CX_AST_USERNAME }}
           CX_AST_PASSWORD: ${{ secrets.CX_AST_PASSWORD }}
           CX_APIKEY:  ${{ secrets.CX_APIKEY }}


### PR DESCRIPTION
### Description

Add base auth uri variable for CI instead of using the scan base auth uri

### References

N/A

### Testing

N/A

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used