### PR TITLE
Clean temporary files after zipping

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -979,28 +979,35 @@ func getUploadURLFromSource(cmd *cobra.Command, uploadsWrapper wrappers.UploadsW
 		}
 	}
 	if zipFilePath != "" {
-		var zipFilePathErr error
-		// Send a request to uploads service
-		var preSignedURL *string
-		preSignedURL, zipFilePathErr = uploadsWrapper.UploadFile(zipFilePath)
-		if zipFilePathErr != nil {
-			return "", "", errors.Wrapf(zipFilePathErr, "%s: Failed to upload sources file\n", failedCreating)
-		}
-		logger.PrintIfVerbose(fmt.Sprintf("Uploaded file to %s\n", *preSignedURL))
-		if unzip || !userProvidedZip {
-			return *preSignedURL, zipFilePath, zipFilePathErr
-		}
-		return *preSignedURL, "", zipFilePathErr
+		return uploadZip(uploadsWrapper, zipFilePath, unzip, userProvidedZip)
 	}
 	return preSignedURL, zipFilePath, nil
 }
 
-func getScaResolverFlags(cmd *cobra.Command, dirPathErr error) (string, string) {
-	scaResolverParams, dirPathErr := cmd.Flags().GetString(commonParams.ScaResolverParamsFlag)
+func uploadZip(uploadsWrapper wrappers.UploadsWrapper, zipFilePath string, unzip bool, userProvidedZip bool) (
+	url, zipPath string,
+	err error,
+) {
+	var zipFilePathErr error
+	// Send a request to uploads service
+	var preSignedURL *string
+	preSignedURL, zipFilePathErr = uploadsWrapper.UploadFile(zipFilePath)
+	if zipFilePathErr != nil {
+		return "", "", errors.Wrapf(zipFilePathErr, "%s: Failed to upload sources file\n", failedCreating)
+	}
+	logger.PrintIfVerbose(fmt.Sprintf("Uploaded file to %s\n", *preSignedURL))
+	if unzip || !userProvidedZip {
+		return *preSignedURL, zipFilePath, zipFilePathErr
+	}
+	return *preSignedURL, "", zipFilePathErr
+}
+
+func getScaResolverFlags(cmd *cobra.Command, dirPathErr error) (scaResolverParams, scaResolver string) {
+	scaResolverParams, dirPathErr = cmd.Flags().GetString(commonParams.ScaResolverParamsFlag)
 	if dirPathErr != nil {
 		scaResolverParams = ""
 	}
-	scaResolver, dirPathErr := cmd.Flags().GetString(commonParams.ScaResolverFlag)
+	scaResolver, dirPathErr = cmd.Flags().GetString(commonParams.ScaResolverFlag)
 	if dirPathErr != nil {
 		scaResolver = ""
 		scaResolverParams = ""

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1860,7 +1860,7 @@ func cleanUpTempZip(zipFilePath string) {
 				tries = tries - 1
 				time.Sleep(time.Duration(cleanupRetryWaitSeconds) * time.Second)
 			} else {
-				logger.Print("Removed temporary zip")
+				logger.PrintIfVerbose("Removed temporary zip")
 				break
 			}
 		}

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -938,10 +938,10 @@ func getUploadURLFromSource(cmd *cobra.Command, uploadsWrapper wrappers.UploadsW
 	}
 
 	var errorUnzippingFile error
-	// apply file filters to zip file
-	unzip := false
-	if (len(sourceDirFilter) > 0 || len(userIncludeFilter) > 0) && len(zipFilePath) > 0 {
-		unzip = true
+
+	userProvidedZip := len(zipFilePath) > 0
+	unzip := (len(sourceDirFilter) > 0 || len(userIncludeFilter) > 0) && userProvidedZip
+	if unzip {
 		directoryPath, errorUnzippingFile = UnzipFile(zipFilePath)
 		if errorUnzippingFile != nil {
 			return "", errorUnzippingFile, ""
@@ -994,7 +994,11 @@ func getUploadURLFromSource(cmd *cobra.Command, uploadsWrapper wrappers.UploadsW
 			return "", errors.Wrapf(zipFilePathErr, "%s: Failed to upload sources file\n", failedCreating), ""
 		}
 		logger.PrintIfVerbose(fmt.Sprintf("Uploaded file to %s\n", *preSignedURL))
-		return *preSignedURL, zipFilePathErr, zipFilePath
+		if unzip || !userProvidedZip {
+			return *preSignedURL, zipFilePathErr, zipFilePath
+		} else {
+			return *preSignedURL, zipFilePathErr, ""
+		}
 	}
 	return preSignedURL, nil, zipFilePath
 }

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -926,7 +926,11 @@ func addScaResults(zipWriter *zip.Writer) error {
 	return nil
 }
 
-func getUploadURLFromSource(cmd *cobra.Command, uploadsWrapper wrappers.UploadsWrapper) (string, string, error) {
+func getUploadURLFromSource(cmd *cobra.Command, uploadsWrapper wrappers.UploadsWrapper) (
+	url string,
+	zipFilePath string,
+	err error,
+) {
 	var preSignedURL string
 
 	sourceDirFilter, _ := cmd.Flags().GetString(commonParams.SourceDirFilterFlag)

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -927,8 +927,7 @@ func addScaResults(zipWriter *zip.Writer) error {
 }
 
 func getUploadURLFromSource(cmd *cobra.Command, uploadsWrapper wrappers.UploadsWrapper) (
-	url string,
-	zipFilePath string,
+	url, zipFilePath string,
 	err error,
 ) {
 	var preSignedURL string

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -954,7 +954,7 @@ func getUploadURLFromSource(cmd *cobra.Command, uploadsWrapper wrappers.UploadsW
 	if directoryPath != "" {
 		var dirPathErr error
 
-		scaResolverParams, scaResolver := getScaResolverFlags(cmd, dirPathErr)
+		scaResolverParams, scaResolver := getScaResolverFlags(cmd)
 
 		// Make sure scaResolver only runs in sca type of scans
 		if strings.Contains(actualScanTypes, commonParams.ScaType) {
@@ -984,7 +984,7 @@ func getUploadURLFromSource(cmd *cobra.Command, uploadsWrapper wrappers.UploadsW
 	return preSignedURL, zipFilePath, nil
 }
 
-func uploadZip(uploadsWrapper wrappers.UploadsWrapper, zipFilePath string, unzip bool, userProvidedZip bool) (
+func uploadZip(uploadsWrapper wrappers.UploadsWrapper, zipFilePath string, unzip, userProvidedZip bool) (
 	url, zipPath string,
 	err error,
 ) {
@@ -1002,8 +1002,8 @@ func uploadZip(uploadsWrapper wrappers.UploadsWrapper, zipFilePath string, unzip
 	return *preSignedURL, "", zipFilePathErr
 }
 
-func getScaResolverFlags(cmd *cobra.Command, dirPathErr error) (scaResolverParams, scaResolver string) {
-	scaResolverParams, dirPathErr = cmd.Flags().GetString(commonParams.ScaResolverParamsFlag)
+func getScaResolverFlags(cmd *cobra.Command) (scaResolverParams, scaResolver string) {
+	scaResolverParams, dirPathErr := cmd.Flags().GetString(commonParams.ScaResolverParamsFlag)
 	if dirPathErr != nil {
 		scaResolverParams = ""
 	}

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -69,6 +69,8 @@ const (
 	containerVolumeFormat           = "%s:/path"
 	containerTempDirPattern         = "kics"
 	kicsContainerPrefixName         = "cli-kics-realtime-"
+	cleanupMaxRetries               = 3
+	cleanupRetryWaitSeconds         = 15
 )
 
 var (
@@ -179,15 +181,18 @@ func scanRealtimeSubCommand() *cobra.Command {
 		StringSliceVar(
 			&aditionalParameters, commonParams.KicsRealtimeAdditionalParams, []string{},
 			"Additional scan options supported by kics. "+
-				"Should follow comma separated format. For example : --additional-params -v, --exclude-results,fec62a97d569662093dbb9739360942f")
+				"Should follow comma separated format. For example : --additional-params -v, --exclude-results,fec62a97d569662093dbb9739360942f",
+		)
 	realtimeScanCmd.PersistentFlags().String(
 		commonParams.KicsRealtimeFile,
 		"",
-		"Path to input file for kics realtime scanner")
+		"Path to input file for kics realtime scanner",
+	)
 	realtimeScanCmd.PersistentFlags().String(
 		commonParams.KicsRealtimeEngine,
 		"docker",
-		"Name in the $PATH for the container engine to run kics. Example:podman.")
+		"Name in the $PATH for the container engine to run kics. Example:podman.",
+	)
 	markFlagAsRequired(realtimeScanCmd, commonParams.KicsRealtimeFile)
 	return realtimeScanCmd
 }
@@ -921,10 +926,7 @@ func addScaResults(zipWriter *zip.Writer) error {
 	return nil
 }
 
-func getUploadURLFromSource(
-	cmd *cobra.Command,
-	uploadsWrapper wrappers.UploadsWrapper,
-) (string, error) {
+func getUploadURLFromSource(cmd *cobra.Command, uploadsWrapper wrappers.UploadsWrapper) (string, error, string) {
 	var preSignedURL string
 
 	sourceDirFilter, _ := cmd.Flags().GetString(commonParams.SourceDirFilterFlag)
@@ -932,15 +934,17 @@ func getUploadURLFromSource(
 
 	zipFilePath, directoryPath, err := definePathForZipFileOrDirectory(cmd)
 	if err != nil {
-		return "", errors.Wrapf(err, "%s: Input in bad format", failedCreating)
+		return "", errors.Wrapf(err, "%s: Input in bad format", failedCreating), ""
 	}
 
 	var errorUnzippingFile error
 	// apply file filters to zip file
+	unzip := false
 	if (len(sourceDirFilter) > 0 || len(userIncludeFilter) > 0) && len(zipFilePath) > 0 {
+		unzip = true
 		directoryPath, errorUnzippingFile = UnzipFile(zipFilePath)
 		if errorUnzippingFile != nil {
-			return "", errorUnzippingFile
+			return "", errorUnzippingFile, ""
 		}
 	}
 
@@ -961,12 +965,24 @@ func getUploadURLFromSource(
 		if strings.Contains(actualScanTypes, commonParams.ScaType) {
 			dirPathErr = runScaResolver(directoryPath, scaResolver, scaResolverParams)
 			if dirPathErr != nil {
-				return "", errors.Wrapf(dirPathErr, "ScaResolver error")
+				if unzip {
+					dirRemovalErr := cleanTempUnzipDirectory(directoryPath)
+					if dirRemovalErr != nil {
+						return "", dirRemovalErr, ""
+					}
+				}
+				return "", errors.Wrapf(dirPathErr, "ScaResolver error"), ""
 			}
 		}
 		zipFilePath, dirPathErr = compressFolder(directoryPath, sourceDirFilter, userIncludeFilter, scaResolver)
+		if unzip {
+			dirRemovalErr := cleanTempUnzipDirectory(directoryPath)
+			if dirRemovalErr != nil {
+				return "", dirRemovalErr, ""
+			}
+		}
 		if dirPathErr != nil {
-			return "", dirPathErr
+			return "", dirPathErr, ""
 		}
 	}
 	if zipFilePath != "" {
@@ -975,12 +991,12 @@ func getUploadURLFromSource(
 		var preSignedURL *string
 		preSignedURL, zipFilePathErr = uploadsWrapper.UploadFile(zipFilePath)
 		if zipFilePathErr != nil {
-			return "", errors.Wrapf(zipFilePathErr, "%s: Failed to upload sources file\n", failedCreating)
+			return "", errors.Wrapf(zipFilePathErr, "%s: Failed to upload sources file\n", failedCreating), ""
 		}
-		logger.PrintIfVerbose(fmt.Sprintf("Uploading file to %s\n", *preSignedURL))
-		return *preSignedURL, zipFilePathErr
+		logger.PrintIfVerbose(fmt.Sprintf("Uploaded file to %s\n", *preSignedURL))
+		return *preSignedURL, zipFilePathErr, zipFilePath
 	}
-	return preSignedURL, nil
+	return preSignedURL, nil, zipFilePath
 }
 
 func UnzipFile(f string) (string, error) {
@@ -1087,7 +1103,7 @@ func runCreateScanCommand(
 		if timeoutMinutes < 0 {
 			return errors.Errorf("--%s should be equal or higher than 0", commonParams.ScanTimeoutFlag)
 		}
-		scanModel, err := createScanModel(cmd, uploadsWrapper, projectsWrapper, groupsWrapper)
+		scanModel, err, zipFilePath := createScanModel(cmd, uploadsWrapper, projectsWrapper, groupsWrapper)
 		if err != nil {
 			return errors.Errorf("%s", err)
 		}
@@ -1130,6 +1146,8 @@ func runCreateScanCommand(
 			}
 		}
 
+		cleanUpTempZip(zipFilePath)
+
 		return nil
 	}
 }
@@ -1150,7 +1168,7 @@ func createScanModel(
 	uploadsWrapper wrappers.UploadsWrapper,
 	projectsWrapper wrappers.ProjectsWrapper,
 	groupsWrapper wrappers.GroupsWrapper,
-) (*wrappers.Scan, error) {
+) (*wrappers.Scan, error, string) {
 	validateScanTypes(cmd)
 
 	var input = []byte("{}")
@@ -1158,7 +1176,7 @@ func createScanModel(
 	// Define type, project and config in scan model
 	err := setupScanTypeProjectAndConfig(&input, cmd, projectsWrapper, groupsWrapper)
 	if err != nil {
-		return nil, err
+		return nil, err, ""
 	}
 
 	// set tags in scan model
@@ -1168,13 +1186,13 @@ func createScanModel(
 	// Try to parse to a scan model in order to manipulate the request payload
 	err = json.Unmarshal(input, &scanModel)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%s: Input in bad format", failedCreating)
+		return nil, errors.Wrapf(err, "%s: Input in bad format", failedCreating), ""
 	}
 
 	// Set up the scan handler (either git or upload)
-	scanHandler, err := setupScanHandler(cmd, uploadsWrapper)
+	scanHandler, err, zipFilePath := setupScanHandler(cmd, uploadsWrapper)
 	if err != nil {
-		return nil, err
+		return nil, err, zipFilePath
 	}
 
 	scanModel.Handler, _ = json.Marshal(scanHandler)
@@ -1185,7 +1203,7 @@ func createScanModel(
 		log.Printf("\n\nScanning branch %s...\n", viper.GetString(commonParams.BranchKey))
 	}
 
-	return &scanModel, nil
+	return &scanModel, nil, zipFilePath
 }
 
 func getUploadType(cmd *cobra.Command) string {
@@ -1199,10 +1217,12 @@ func getUploadType(cmd *cobra.Command) string {
 	return "upload"
 }
 
-func setupScanHandler(
-	cmd *cobra.Command,
-	uploadsWrapper wrappers.UploadsWrapper,
-) (wrappers.ScanHandler, error) {
+func setupScanHandler(cmd *cobra.Command, uploadsWrapper wrappers.UploadsWrapper) (
+	wrappers.ScanHandler,
+	error,
+	string,
+) {
+	zipFilePath := ""
 	scanHandler := wrappers.ScanHandler{}
 	scanHandler.Branch = viper.GetString(commonParams.BranchKey)
 
@@ -1213,9 +1233,11 @@ func setupScanHandler(
 
 		scanHandler.RepoURL = strings.TrimSpace(source)
 	} else {
-		uploadURL, err := getUploadURLFromSource(cmd, uploadsWrapper)
+		var err error
+		var uploadURL string
+		uploadURL, err, zipFilePath = getUploadURLFromSource(cmd, uploadsWrapper)
 		if err != nil {
-			return scanHandler, err
+			return scanHandler, err, zipFilePath
 		}
 
 		scanHandler.UploadURL = uploadURL
@@ -1228,20 +1250,20 @@ func setupScanHandler(
 		sshKeyPath, _ := cmd.Flags().GetString(commonParams.SSHKeyFlag)
 
 		if strings.TrimSpace(sshKeyPath) == "" {
-			return scanHandler, errors.New("flag needs an argument: --ssh-key")
+			return scanHandler, errors.New("flag needs an argument: --ssh-key"), ""
 		}
 
 		source, _ := cmd.Flags().GetString(commonParams.SourcesFlag)
 		sourceTrimmed := strings.TrimSpace(source)
 
 		if !util.IsSSHURL(sourceTrimmed) {
-			return scanHandler, errors.New(invalidSSHSource)
+			return scanHandler, errors.New(invalidSSHSource), ""
 		}
 
 		err = defineSSHCredentials(strings.TrimSpace(sshKeyPath), &scanHandler)
 	}
 
-	return scanHandler, err
+	return scanHandler, err, zipFilePath
 }
 
 func defineSSHCredentials(sshKeyPath string, handler *wrappers.ScanHandler) error {
@@ -1809,4 +1831,39 @@ func runKicsScan(cmd *cobra.Command, volumeMap, tempDir string, additionalParame
 	}
 
 	return nil
+}
+
+func cleanTempUnzipDirectory(directoryPath string) error {
+	logger.PrintIfVerbose("Cleaning up temporary directory: " + directoryPath)
+	return os.RemoveAll(directoryPath)
+}
+
+func cleanUpTempZip(zipFilePath string) {
+	if zipFilePath != "" {
+		logger.PrintIfVerbose("Cleaning up temporary zip: " + zipFilePath)
+		tries := cleanupMaxRetries
+		for tries > 0 {
+			zipRemoveErr := os.Remove(zipFilePath)
+			if zipRemoveErr != nil {
+				logger.PrintIfVerbose(
+					fmt.Sprintf(
+						"Failed to remove temporary zip: %d in %d: %v",
+						cleanupMaxRetries-tries,
+						cleanupMaxRetries,
+						zipRemoveErr,
+					),
+				)
+				tries = tries - 1
+				time.Sleep(time.Duration(cleanupRetryWaitSeconds) * time.Second)
+			} else {
+				logger.Print("Removed temporary zip")
+				break
+			}
+		}
+		if tries == 0 {
+			logger.PrintIfVerbose("Failed to remove temporary zip " + zipFilePath)
+		}
+	} else {
+		logger.PrintIfVerbose("No temporary zip to clean")
+	}
 }

--- a/internal/logger/utils.go
+++ b/internal/logger/utils.go
@@ -19,13 +19,17 @@ var sanitizeFlags = []string{
 	params.SCMTokenFlag,
 }
 
+func Print(msg string) {
+	if utf8.Valid([]byte(msg)) {
+		log.Print(sanitizeLogs(msg))
+	} else {
+		log.Print("Request contains binary data and cannot be printed!")
+	}
+}
+
 func PrintIfVerbose(msg string) {
 	if viper.GetBool(params.DebugFlag) {
-		if utf8.Valid([]byte(msg)) {
-			log.Print(sanitizeLogs(msg))
-		} else {
-			log.Print("Request contains binary data and cannot be printed!")
-		}
+		Print(msg)
 	}
 }
 

--- a/internal/wrappers/uploads-http.go
+++ b/internal/wrappers/uploads-http.go
@@ -31,9 +31,9 @@ func (u *UploadsHTTPWrapper) UploadFile(sourcesFile string) (*string, error) {
 		return nil, errors.Errorf("Failed to open file %s: %s", sourcesFile, err.Error())
 	}
 	// Close the file later
-	defer func(file *os.File) {
+	defer func() {
 		_ = file.Close()
-	}(file)
+	}()
 
 	// read all of the contents of our uploaded file into a
 	// byte array
@@ -46,7 +46,9 @@ func (u *UploadsHTTPWrapper) UploadFile(sourcesFile string) (*string, error) {
 	if err != nil {
 		return nil, errors.Errorf("Invoking HTTP request to upload file failed - %s", err.Error())
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -24,20 +25,12 @@ import (
 )
 
 const (
-	fileSourceFlag                = "--file"
-	fileSourceValue               = "data/Dockerfile"
-	fileSourceValueVul            = "data/mock.dockerfile"
-	fileSourceIncorrectValue      = "data/source.zip"
-	fileSourceIncorrectValueError = "data/source.zip. Provided file is not supported by kics"
-	fileSourceError               = "flag needs an argument: --file"
-	engineFlag                    = "--engine"
-	engineValue                   = "docker"
-	engineError                   = "flag needs an argument: --engine"
-	additionalParamsFlag          = "--additional-params"
-	additionalParamsValue         = "-v"
-	additionalParamsError         = "flag needs an argument: --additional-params"
-	scanCommand                   = "scan"
-	kicsRealtimeCommand           = "kics-realtime"
+	fileSourceValue       = "data/Dockerfile"
+	fileSourceValueVul    = "data/mock.dockerfile"
+	engineValue           = "docker"
+	additionalParamsValue = "-v"
+	scanCommand           = "scan"
+	kicsRealtimeCommand   = "kics-realtime"
 )
 
 // Type for scan workflow response, used to assert the validity of the command's response
@@ -68,6 +61,11 @@ func TestScansE2E(t *testing.T) {
 	defer deleteProject(t, projectID)
 
 	executeScanAssertions(t, projectID, scanID, Tags)
+	glob, err := filepath.Glob(filepath.Join(os.TempDir(), "cx*.zip"))
+	if err != nil {
+		return
+	}
+	assert.Equal(t, len(glob), 0, "Zip file not removed")
 }
 
 // Perform a nowait scan and poll status until completed

--- a/test/integration/util_command.go
+++ b/test/integration/util_command.go
@@ -146,7 +146,7 @@ func executeCmdWithTimeOutNilAssertion(
 func executeWithTimeout(cmd *cobra.Command, timeout time.Duration, args ...string) error {
 
 	args = append(args, flag(params.DebugFlag), flag(params.RetryFlag), "3", flag(params.RetryDelayFlag), "5")
-	// args = appendProxyArgs(args)
+	args = appendProxyArgs(args)
 	cmd.SetArgs(args)
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)


### PR DESCRIPTION
### Description

When zipping directories or unzipping for filtering, cleanup any created temporary files.

### References

AST-12968

### Testing

Assert no files exist of pattern cx-*.zip in the temp dir after creating a scan

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used