### PR TITLE
Warn when dangling symbolic links is found instead of failing

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -795,7 +795,8 @@ func handleFile(
 		dat, err := ioutil.ReadFile(parentDir + file.Name())
 		if err != nil {
 			if os.IsNotExist(err) {
-				return errors.WithMessage(err, "found dangling symbolic link, aborting")
+				logger.PrintfIfVerbose("Skipping dangling symbolic link: %s: %v", fileName, err)
+				return nil
 			}
 			return err
 		}

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -73,6 +73,7 @@ const (
 	invalidEngineMessage            = "Please verify if engine is installed and running"
 	cleanupMaxRetries               = 3
 	cleanupRetryWaitSeconds         = 15
+	DanglingSymlinkError            = "Skipping dangling symbolic link"
 )
 
 var (
@@ -795,7 +796,7 @@ func handleFile(
 		dat, err := ioutil.ReadFile(parentDir + file.Name())
 		if err != nil {
 			if os.IsNotExist(err) {
-				logger.PrintfIfVerbose("Skipping dangling symbolic link: %s: %v", fileName, err)
+				logger.PrintfIfVerbose("%s: %s: %v", DanglingSymlinkError, fileName, err)
 				return nil
 			}
 			return err

--- a/internal/logger/utils.go
+++ b/internal/logger/utils.go
@@ -28,13 +28,17 @@ func Print(msg string) {
 }
 
 func Printf(msg string, args ...interface{}) {
-	log.Print(fmt.Sprintf(msg, args...))
+	Print(fmt.Sprintf(msg, args...))
 }
 
 func PrintIfVerbose(msg string) {
 	if viper.GetBool(params.DebugFlag) {
 		Print(msg)
 	}
+}
+
+func PrintfIfVerbose(msg string, args ...interface{}) {
+	PrintfIfVerbose(fmt.Sprintf(msg, args...))
 }
 
 func PrintRequest(r *http.Request) {

--- a/internal/logger/utils.go
+++ b/internal/logger/utils.go
@@ -38,7 +38,7 @@ func PrintIfVerbose(msg string) {
 }
 
 func PrintfIfVerbose(msg string, args ...interface{}) {
-	PrintfIfVerbose(fmt.Sprintf(msg, args...))
+	PrintIfVerbose(fmt.Sprintf(msg, args...))
 }
 
 func PrintRequest(r *http.Request) {

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -305,12 +305,18 @@ func TestBrokenLinkScan(t *testing.T) {
 		flag(params.IncludeFilterFlag), "broken_link.txt",
 	}
 
-	cmd, buffer := createRedirectedTestCommand(t)
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+
+	cmd := createASTIntegrationTestCommand(t)
 	err := execute(cmd, args...)
 
 	assert.NilError(t, err)
 
-	output, err := io.ReadAll(buffer)
+	output, err := io.ReadAll(&buf)
 
 	assert.NilError(t, err)
 


### PR DESCRIPTION
### Description

Warn when dangling symbolic links is found instead of failing

### References

00143952

### Testing

Assert the warning in the broken link test

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used