### PR TITLE
Improving --kics-platforms flag helper

### DIFF
--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -53,7 +53,7 @@ const (
 )
 
 var filterResultsListFlagUsage = fmt.Sprintf(
-	"Filter the list of results. Use ';' as the delimeter for arrays. Available filters are: %s",
+	"Filter the list of results. Use ';' as the delimiter for arrays. Available filters are: %s",
 	strings.Join(
 		[]string{
 			commonParams.ScanIDQueryParam,

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -439,7 +439,7 @@ func scanCreateSubCommand(
 	)
 	createScanCmd.PersistentFlags().String(commonParams.SastFilterFlag, "", commonParams.SastFilterUsage)
 	createScanCmd.PersistentFlags().String(commonParams.KicsFilterFlag, "", commonParams.KicsFilterUsage)
-	createScanCmd.PersistentFlags().String(commonParams.KicsPlatformsFlag, "", commonParams.KicsPlatformsFlagUsage)
+	createScanCmd.PersistentFlags().StringSlice(commonParams.KicsPlatformsFlag, []string{}, commonParams.KicsPlatformsFlagUsage)
 	createScanCmd.PersistentFlags().String(commonParams.ScaFilterFlag, "", commonParams.ScaFilterUsage)
 	addResultFormatFlag(
 		createScanCmd,

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -114,7 +114,7 @@ const (
 	SSHValue                     = "ssh-value"
 	KicsContainerNameKey         = "kics-container-name"
 	KicsPlatformsFlag            = "kics-platforms"
-	KicsPlatformsFlagUsage       = "KICS Platform Flag"
+	KicsPlatformsFlagUsage       = "KICS Platform Flag. Use ';' as the delimiter for arrays."
 
 	// INDIVIDUAL FILTER FLAGS
 	SastFilterFlag  = "sast-filter"

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -114,7 +114,7 @@ const (
 	SSHValue                     = "ssh-value"
 	KicsContainerNameKey         = "kics-container-name"
 	KicsPlatformsFlag            = "kics-platforms"
-	KicsPlatformsFlagUsage       = "KICS Platform Flag. Use ';' as the delimiter for arrays."
+	KicsPlatformsFlagUsage       = "KICS Platform Flag. Use ',' as the delimiter for arrays."
 
 	// INDIVIDUAL FILTER FLAGS
 	SastFilterFlag  = "sast-filter"


### PR DESCRIPTION
### Description

Changes in KICS Platform Flag helper

when typed: 

`cx scan create --help`

helper will print:

` --kics-platforms strings       KICS Platform Flag. Use ',' as the delimiter for arrays.`

### References

https://checkmarx.atlassian.net/browse/AST-15470?atlOrigin=eyJpIjoiMDVmNWM2ZTgzMzU0NDBjNWJjMWM1OGFmOTBiYTkxOWYiLCJwIjoiaiJ9

### Testing

Manual tests

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used