### PR TITLE
Fix for threshold

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1482,7 +1482,12 @@ func parseThreshold(threshold string) map[string]int {
 		for _, limits := range thresholdLimits {
 			limit := strings.Split(limits, "=")
 			if len(limit) > 1 {
-				thresholdMap[strings.ToLower(limit[0])], _ = strconv.Atoi(limit[1])
+				intLimit, err := strconv.Atoi(limit[1])
+				if err != nil {
+					log.Println("Error parsing threshold limit: ", err)
+				} else {
+					thresholdMap[strings.ToLower(limit[0])] = intLimit
+				}
 			}
 		}
 	}

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1439,6 +1439,7 @@ func applyThreshold(
 		return nil
 	}
 
+	threshold = strings.ReplaceAll(threshold, " ", "")
 	thresholdMap := parseThreshold(threshold)
 
 	summaryMap, err := getSummaryThresholdMap(resultsWrapper, scanResponseModel)

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -3,6 +3,7 @@
 package commands
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -393,4 +394,25 @@ func TestCreateScanResubmit(t *testing.T) {
 
 func TestCreateScanResubmitWithScanTypes(t *testing.T) {
 	execCmdNilAssertion(t, "scan", "create", "--project-name", "MOCK", "-s", dummyRepo, "-b", "dummy_branch", "--scan-types", "sast,kics,sca", "--debug", "--resubmit")
+}
+
+func Test_parseThresholdSuccess(t *testing.T) {
+	var threshold string
+	var want map[string]int
+	want = make(map[string]int)
+	want[" kics - low"] = 1
+	threshold = " KICS - LoW=1"
+	if got := parseThreshold(threshold); !reflect.DeepEqual(got, want) {
+		t.Errorf("parseThreshold() = %v, want %v", got, want)
+	}
+}
+
+func Test_parseThresholdParseError(t *testing.T) {
+	var threshold string
+	var want map[string]int
+	want = make(map[string]int)
+	threshold = " KICS - LoW=error"
+	if got := parseThreshold(threshold); !reflect.DeepEqual(got, want) {
+		t.Errorf("parseThreshold() = %v, want %v", got, want)
+	}
 }

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -397,21 +397,17 @@ func TestCreateScanResubmitWithScanTypes(t *testing.T) {
 }
 
 func Test_parseThresholdSuccess(t *testing.T) {
-	var threshold string
-	var want map[string]int
-	want = make(map[string]int)
+	want := make(map[string]int)
 	want[" kics - low"] = 1
-	threshold = " KICS - LoW=1"
+	threshold := " KICS - LoW=1"
 	if got := parseThreshold(threshold); !reflect.DeepEqual(got, want) {
 		t.Errorf("parseThreshold() = %v, want %v", got, want)
 	}
 }
 
 func Test_parseThresholdParseError(t *testing.T) {
-	var threshold string
-	var want map[string]int
-	want = make(map[string]int)
-	threshold = " KICS - LoW=error"
+	want := make(map[string]int)
+	threshold := " KICS - LoW=error"
 	if got := parseThreshold(threshold); !reflect.DeepEqual(got, want) {
 		t.Errorf("parseThreshold() = %v, want %v", got, want)
 	}

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/checkmarx/ast-cli/internal/commands/util"
 	"github.com/checkmarx/ast-cli/internal/commands"
+	"github.com/checkmarx/ast-cli/internal/commands/util"
 	"github.com/checkmarx/ast-cli/internal/commands/util/printer"
 	"github.com/checkmarx/ast-cli/internal/params"
 	"github.com/checkmarx/ast-cli/internal/wrappers"
@@ -200,6 +200,25 @@ func TestScanCreateWithThreshold(t *testing.T) {
 
 	err, _ := executeCommand(t, args...)
 	assertError(t, err, "Threshold check finished with status Failed")
+}
+
+// Create a scan with the sources
+// Assert the scan completes
+func TestScanCreateWithThresholdParseError(t *testing.T) {
+	_, projectName := getRootProject(t)
+
+	args := []string{
+		"scan", "create",
+		flag(params.ProjectName), projectName,
+		flag(params.SourcesFlag), Zip,
+		flag(params.ScanTypes), "sast",
+		flag(params.PresetName), "Checkmarx Default",
+		flag(params.Threshold), "sast-high=error",
+		flag(params.BranchFlag), "dummy_branch",
+	}
+
+	err, _ := executeCommand(t, args...)
+	assert.NilError(t, err, "")
 }
 
 // Create a scan with the sources


### PR DESCRIPTION
Threshold flag issues while whitespaces at the end


### Description
Example:

`
./cx.exe scan create --scan-types kics --project-name project-s https://github.com/checkmarx/project--branch main --threshold "kics-low=  1      " 
`
was getting a parsing error while trying to convert the limit value (string) to an integer.

Now it's possible to see this error in logs, and you will not get an error putting whitespace at the end of the threshold value


### References

https://checkmarx.atlassian.net/browse/AST-17738?atlOrigin=eyJpIjoiOTQ1NjJjZTZmNGUxNDQ3NWEyMzYwOTQ2ZjM1OTQzOGUiLCJwIjoiaiJ9

### Testing

Unity tests

and 

Integration tests

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used