### PR TITLE
Fix api security

### DIFF
--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -381,7 +381,7 @@ func executeScanAssertions(t *testing.T, projectID, scanID string, tags map[stri
 }
 
 func createScan(t *testing.T, source string, tags map[string]string) (string, string) {
-	return executeCreateScan(t, getCreateArgs(source, tags, "sast,iac-security"))
+	return executeCreateScan(t, getCreateArgs(source, tags, "sast,iac-security,api-security"))
 }
 
 func createScanNoWait(t *testing.T, source string, tags map[string]string) (string, string) {


### PR DESCRIPTION
Not run api security when the scanner is not selected. 

### Description

### References

### Testing


### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used