### PR TITLE
AST-22649 Improve memory usage when uploading zip and limit request dump for printing to 1MB

### DIFF
--- a/internal/logger/utils.go
+++ b/internal/logger/utils.go
@@ -12,6 +12,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+const ContentLengthLimit = 1000000 // 1mb in bytes
+
 var sanitizeFlags = []string{
 	params.AstAPIKey, params.AccessKeyIDConfigKey, params.AccessKeySecretConfigKey,
 	params.UsernameFlag, params.PasswordFlag,
@@ -44,7 +46,7 @@ func PrintfIfVerbose(msg string, args ...interface{}) {
 
 func PrintRequest(r *http.Request) {
 	PrintIfVerbose("Sending API request to:")
-	requestDump, err := httputil.DumpRequest(r, r.ContentLength < 1000000) // 1mb
+	requestDump, err := httputil.DumpRequest(r, r.ContentLength < ContentLengthLimit)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/internal/logger/utils.go
+++ b/internal/logger/utils.go
@@ -44,9 +44,10 @@ func PrintfIfVerbose(msg string, args ...interface{}) {
 
 func PrintRequest(r *http.Request) {
 	PrintIfVerbose("Sending API request to:")
-	requestDump, err := httputil.DumpRequest(r, true)
+	requestDump, err := httputil.DumpRequest(r, r.ContentLength < 1000000) // 1mb
 	if err != nil {
 		fmt.Println(err)
+		return
 	}
 	PrintIfVerbose(string(requestDump))
 }

--- a/internal/wrappers/auth-http.go
+++ b/internal/wrappers/auth-http.go
@@ -41,10 +41,7 @@ func (a *AuthHTTPWrapper) CreateOauth2Client(
 	createClientPath = strings.Replace(createClientPath, "organization", tenant, 1)
 	a.SetPath(createClientPath)
 	// send the request
-	res, err := SendHTTPRequestPasswordAuth(
-		http.MethodPost, a.path, bytes.NewBuffer(jsonBytes), clientTimeout,
-		username, password, adminClientID, adminClientSecret,
-	)
+	res, err := SendHTTPRequestPasswordAuth(http.MethodPost, bytes.NewBuffer(jsonBytes), clientTimeout, username, password, adminClientID, adminClientSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -171,9 +171,24 @@ func SendHTTPRequestByFullURL(
 	accessToken string,
 	bodyPrint bool,
 ) (*http.Response, error) {
+	return SendHTTPRequestByFullURLContentLength(method, fullURL, body, -1, auth, timeout, accessToken, bodyPrint)
+}
+
+func SendHTTPRequestByFullURLContentLength(
+	method, fullURL string,
+	body io.Reader,
+	contentLength int64,
+	auth bool,
+	timeout uint,
+	accessToken string,
+	bodyPrint bool,
+) (*http.Response, error) {
 	req, err := http.NewRequest(method, fullURL, body)
 	if err != nil {
 		return nil, err
+	}
+	if contentLength >= 0 {
+		req.ContentLength = contentLength
 	}
 	client := GetClient(timeout)
 	setAgentName(req)
@@ -225,10 +240,7 @@ func addReqMonitor(req *http.Request) *http.Request {
 	return req
 }
 
-func SendHTTPRequestPasswordAuth(
-	method, path string, body io.Reader, timeout uint,
-	username, password, adminClientID, adminClientSecret string,
-) (*http.Response, error) {
+func SendHTTPRequestPasswordAuth(method string, body io.Reader, timeout uint, username, password, adminClientID, adminClientSecret string) (*http.Response, error) {
 	u, err := getAuthURI()
 	if err != nil {
 		return nil, err
@@ -252,12 +264,6 @@ func SendHTTPRequestPasswordAuth(
 		return nil, err
 	}
 	return resp, nil
-}
-
-func GetCleanURL(path string) string {
-	cleanURL := strings.TrimSpace(viper.GetString(commonParams.BaseURIKey))
-	cleanURL = strings.Trim(cleanURL, "/")
-	return fmt.Sprintf("%s/%s", cleanURL, path)
 }
 
 func SendPrivateHTTPRequestWithQueryParams(

--- a/internal/wrappers/uploads-http.go
+++ b/internal/wrappers/uploads-http.go
@@ -1,9 +1,7 @@
 package wrappers
 
 import (
-	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -40,12 +38,6 @@ func (u *UploadsHTTPWrapper) UploadFile(sourcesFile string) (*string, error) {
 		_ = file.Close()
 	}()
 
-	// read all of the contents of our uploaded file into a
-	// byte array
-	fileBytes, err := ioutil.ReadAll(file)
-	if err != nil {
-		return nil, errors.Errorf("Failed to read file %s: %s", sourcesFile, err.Error())
-	}
 	accessToken, err := GetAccessToken()
 	if err != nil {
 		return nil, err
@@ -54,7 +46,12 @@ func (u *UploadsHTTPWrapper) UploadFile(sourcesFile string) (*string, error) {
 	if err != nil {
 		return nil, errors.Errorf("Failed to unmarshal pre-signed URL - %s", err.Error())
 	}
-	resp, err := SendHTTPRequestByFullURL(http.MethodPut, *preSignedURL, bytes.NewReader(fileBytes), true, NoTimeout, accessToken, true)
+
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, errors.Errorf("Failed to stat file %s: %s", sourcesFile, err.Error())
+	}
+	resp, err := SendHTTPRequestByFullURLContentLength(http.MethodPut, *preSignedURL, file, stat.Size(), true, NoTimeout, accessToken, true)
 	if err != nil {
 		return nil, errors.Errorf("Invoking HTTP request to upload file failed - %s", err.Error())
 	}
@@ -78,7 +75,9 @@ func (u *UploadsHTTPWrapper) getPresignedURLForUploading() (*string, error) {
 		return nil, errors.Errorf("invoking HTTP request to get pre-signed URL failed - %s", err.Error())
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	decoder := json.NewDecoder(resp.Body)
 


### PR DESCRIPTION


### Description

Improve memory usage when uploading zip and limit request dump for printing to 1MB
- General warning cleanup

### References

https://checkmarx.atlassian.net/browse/AST-22649

### Testing

N/A (performance improvements)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used