### PR TITLE
Add environment variable CX_HTTP_PROXY to override HTTP_PROXY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,6 @@ name: Checkmarx One CLI
 
 on:
   pull_request:
-  workflow_dispatch:
-  push:
-    branches:
-      - cx-http-proxy
 
 jobs:
   unit-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Checkmarx One CLI
 on:
   pull_request:
   workflow_dispatch:
+  push:
+    branches:
+      - cx-http-proxy
 
 jobs:
   unit-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Checkmarx One CLI
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   unit-tests:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ const (
 
 func main() {
 	var err error
+	bindProxy()
 	bindKeysToEnvAndDefault()
 	configuration.LoadConfiguration()
 	scans := viper.GetString(params.ScansPathKey)
@@ -115,6 +116,18 @@ func bindKeysToEnvAndDefault() {
 			exitIfError(err)
 		}
 		viper.SetDefault(b.Key, b.Default)
+	}
+}
+
+func bindProxy() {
+	err := viper.BindEnv(params.ProxyKey, params.CxProxyEnv, params.ProxyEnv)
+	if err != nil {
+		exitIfError(err)
+	}
+	viper.SetDefault(params.ProxyKey, "")
+	err = os.Setenv(params.ProxyEnv, viper.GetString(params.ProxyKey))
+	if err != nil {
+		exitIfError(err)
 	}
 }
 

--- a/internal/params/binds.go
+++ b/internal/params/binds.go
@@ -6,7 +6,6 @@ var EnvVarsBinds = []struct {
 	Default string
 }{
 	{BaseURIKey, BaseURIEnv, ""},
-	{ProxyKey, ProxyEnv, ""},
 	{ProxyTypeKey, ProxyTypeEnv, "basic"},
 	{ProxyDomainKey, ProxyDomainEnv, ""},
 	{BaseAuthURIKey, BaseAuthURIEnv, ""},

--- a/internal/params/envs.go
+++ b/internal/params/envs.go
@@ -6,6 +6,7 @@ const (
 	BaseURIEnv                          = "CX_BASE_URI"
 	ClientTimeoutEnv                    = "CX_TIMEOUT"
 	ProxyEnv                            = "HTTP_PROXY"
+	CxProxyEnv                          = "CX_HTTP_PROXY"
 	ProxyTypeEnv                        = "CX_PROXY_AUTH_TYPE"
 	ProxyDomainEnv                      = "CX_PROXY_NTLM_DOMAIN"
 	BaseAuthURIEnv                      = "CX_BASE_AUTH_URI"

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -168,41 +167,6 @@ func TestFailProxyAuth(t *testing.T) {
 	assert.Assert(t, err != nil, "Executing without proxy should fail")
 	//goland:noinspection GoNilness
 	assert.Assert(t, strings.Contains(strings.ToLower(err.Error()), "could not reach provided"))
-}
-
-func TestFailProxyAuthCxHttpProxy(t *testing.T) {
-	proxyUser := viper.GetString(ProxyUserEnv)
-	proxyPw := viper.GetString(ProxyPwEnv)
-	proxyPort := viper.GetInt(ProxyPortEnv)
-	proxyHost := viper.GetString(ProxyHostEnv)
-	proxyArg := fmt.Sprintf(ProxyURLTmpl, proxyUser, proxyPw, proxyHost, proxyPort)
-
-	proxyEnv := os.Getenv(params.ProxyEnv)
-	_ = os.Setenv(params.ProxyEnv, proxyArg)
-	defer func() {
-		_ = os.Setenv(params.ProxyEnv, proxyEnv)
-	}()
-
-	validate := createASTIntegrationTestCommand(t)
-
-	args := []string{"auth", "validate", flag(params.DebugFlag)}
-	validate.SetArgs(args)
-
-	err := validate.Execute()
-	assert.NilError(t, err)
-
-	cxProxyEnv := os.Getenv(params.CxProxyEnv)
-	_ = os.Setenv(params.CxProxyEnv, "http://localhost:55555")
-	defer func() {
-		_ = os.Setenv(params.CxProxyEnv, cxProxyEnv)
-	}()
-
-	validate = createASTIntegrationTestCommand(t)
-
-	validate.SetArgs(args)
-
-	err = validate.Execute()
-	assert.Assert(t, err != nil, "Overriding proxy by CxProxyEnv should fail the scan")
 }
 
 // assert success authentication

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -167,6 +168,34 @@ func TestFailProxyAuth(t *testing.T) {
 	assert.Assert(t, err != nil, "Executing without proxy should fail")
 	//goland:noinspection GoNilness
 	assert.Assert(t, strings.Contains(strings.ToLower(err.Error()), "could not reach provided"))
+}
+
+func TestFailProxyAuthByEnv(t *testing.T) {
+	proxyValue := os.Getenv(params.ProxyEnv)
+	defer func() {
+		_ = os.Setenv(params.ProxyEnv, proxyValue)
+	}()
+	_ = os.Setenv(params.ProxyEnv, buildProxyURL())
+
+	validate := createASTIntegrationTestCommand(t)
+	args := []string{"auth", "validate", flag(params.DebugFlag)}
+	validate.SetArgs(args)
+	err := validate.Execute()
+	assert.NilError(t, err)
+
+	proxyValue = os.Getenv(params.CxProxyEnv)
+	defer func() {
+		_ = os.Setenv(params.CxProxyEnv, proxyValue)
+	}()
+	_ = os.Setenv(params.CxProxyEnv, "http://localhost:55555")
+
+	viper.Reset()
+
+	validate = createASTIntegrationTestCommand(t)
+	args = append(args, flag(params.RetryFlag), string(rune(0)))
+	validate.SetArgs(args)
+	err = validate.Execute()
+	assert.Assert(t, err != nil)
 }
 
 // assert success authentication

--- a/test/integration/util_command.go
+++ b/test/integration/util_command.go
@@ -46,7 +46,7 @@ func bindProxy(t *testing.T) {
 		assert.NilError(t, err)
 	}
 	viper.SetDefault(params.ProxyKey, "")
-	err = os.Setenv("HTTP_PROXY", viper.GetString(params.ProxyKey))
+	err = os.Setenv(params.ProxyEnv, viper.GetString(params.ProxyKey))
 	if err != nil {
 		assert.NilError(t, err)
 	}
@@ -198,13 +198,18 @@ func executeWithTimeout(cmd *cobra.Command, timeout time.Duration, args ...strin
 }
 
 func appendProxyArgs(args []string) []string {
+	argsWithProxy := append(args, flag(params.ProxyFlag))
+	argsWithProxy = append(argsWithProxy, buildProxyURL())
+	return argsWithProxy
+}
+
+func buildProxyURL() string {
 	proxyUser := viper.GetString(ProxyUserEnv)
 	proxyPw := viper.GetString(ProxyPwEnv)
 	proxyPort := viper.GetInt(ProxyPortEnv)
 	proxyHost := viper.GetString(ProxyHostEnv)
-	argsWithProxy := append(args, flag(params.ProxyFlag))
-	argsWithProxy = append(argsWithProxy, fmt.Sprintf(ProxyURLTmpl, proxyUser, proxyPw, proxyHost, proxyPort))
-	return argsWithProxy
+	proxyURL := fmt.Sprintf(ProxyURLTmpl, proxyUser, proxyPw, proxyHost, proxyPort)
+	return proxyURL
 }
 
 // Assert error with expected message

--- a/test/integration/util_command.go
+++ b/test/integration/util_command.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -39,8 +40,21 @@ func bindKeysToEnvAndDefault(t *testing.T) {
 	}
 }
 
+func bindProxy(t *testing.T) {
+	err := viper.BindEnv(params.ProxyKey, params.CxProxyEnv, params.ProxyEnv)
+	if err != nil {
+		assert.NilError(t, err)
+	}
+	viper.SetDefault(params.ProxyKey, "")
+	err = os.Setenv("HTTP_PROXY", viper.GetString(params.ProxyKey))
+	if err != nil {
+		assert.NilError(t, err)
+	}
+}
+
 // Create a command to execute in tests
 func createASTIntegrationTestCommand(t *testing.T) *cobra.Command {
+	bindProxy(t)
 	bindKeysToEnvAndDefault(t)
 	_ = viper.BindEnv(pat)
 	viper.AutomaticEnv()


### PR DESCRIPTION
### Description

Add environment variable CX_HTTP_PROXY to override HTTP_PROXY

### References

AST-23205

### Testing

Test that succeeds authentication with HTTP_PROXY environment variable and then fails authentication with an invalid value in CX_HTTP_PROXY while keeping the HTTP_PROXY value

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used