### PR TITLE
adding empty array to results field instead of nil

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -2176,6 +2176,9 @@ func runKicsScan(cmd *cobra.Command, volumeMap, tempDir string, additionalParame
 	*/
 	if err == nil {
 		// no results
+		if resultsModel.Results == nil {
+			resultsModel.Results = []wrappers.KicsQueries{}
+		}
 		errs = printKicsResults(&resultsModel)
 		if errs != nil {
 			return errors.Errorf("%s", errs)


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

- Fixing nil value in kics realtime results. When there are 0 results the field is populated with an empty string.

### References

- https://checkmarx.atlassian.net/browse/AST-27057

### Testing

- Integration and unit tests

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used