### PR TITLE
Adding --agent flag error message (code 113)

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1408,6 +1408,9 @@ func runCreateScanCommand(
 		}
 		// Checking the response
 		if errorModel != nil {
+			if wrappers.CodeErrorToErrorMessage[errorModel.Code] != "" {
+				return errors.Errorf(ErrorCodeFormat, failedCreating, errorModel.Code, wrappers.CodeErrorToErrorMessage[errorModel.Code])
+			}
 			return errors.Errorf(ErrorCodeFormat, failedCreating, errorModel.Code, errorModel.Message)
 		} else if scanResponseModel != nil {
 			scanResponseModel = enrichScanResponseModel(cmd, scanResponseModel)

--- a/internal/wrappers/ast.go
+++ b/internal/wrappers/ast.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 )
 
+var CodeErrorToErrorMessage map[int]string = map[int]string{
+	133: "--agent flag content length is too long (up to 20 characters)",
+}
+
 type ErrorModel struct {
 	Message string `json:"message"`
 	Type    string `json:"type"`

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -1174,3 +1174,20 @@ func TestCreateScanSBOMReportFormatWrongTenant(t *testing.T) {
 	err, _ := executeCommand(t, args...)
 	assertError(t, err, "SBOM report is currently in beta mode and not available for this tenant type")
 }
+
+func TestCreateScanLongAgentFlagError(t *testing.T) {
+	_, projectName := getRootProject(t)
+
+	args := []string{
+		scanCommand, "create",
+		flag(params.ProjectName), projectName,
+		flag(params.SourcesFlag), Zip,
+		flag(params.ScanTypes), "sca",
+		flag(params.PresetName), "Checkmarx Default",
+		flag(params.BranchFlag), "dummy_branch",
+		flag(params.ProjectTagList), "integration",
+		flag(params.AgentFlag), "123456789012345678901",
+	}
+	err, _ := executeCommand(t, args...)
+	assertError(t, err, "--agent flag content length is too long (up to 20 characters)")
+}


### PR DESCRIPTION
### Description

I was getting an error using Visual Studio Extension because of the --agent flag and had problems noticing what was wrong. Just translating some code to error. 

before:
![image](https://github.com/Checkmarx/ast-cli/assets/114568996/0d477bce-f75f-4274-bf32-70c613ff28df)

after:
![image](https://github.com/Checkmarx/ast-cli/assets/114568996/9cd33b81-20eb-4a24-a413-5d8b5f48d8be)

Need to improve this error message btw.

### Testing

integration tests added

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used