### PR TITLE
Fix for pdf report not using default engines

### DIFF
--- a/.github/workflows/one-scan.yml
+++ b/.github/workflows/one-scan.yml
@@ -20,4 +20,4 @@ jobs:
           cx_tenant: ${{ secrets.AST_RND_SCANS_TENANT }}
           cx_client_id: ${{ secrets.AST_RND_SCANS_CLIENT_ID }}
           cx_client_secret: ${{ secrets.AST_RND_SCANS_CLIENT_SECRET }}
-          additional_params: --tags galactica-team --threshold "sast-high=1"
+          additional_params: --tags galactica-team --threshold "sast-high=1" --debug

--- a/.github/workflows/one-scan.yml
+++ b/.github/workflows/one-scan.yml
@@ -20,4 +20,4 @@ jobs:
           cx_tenant: ${{ secrets.AST_RND_SCANS_TENANT }}
           cx_client_id: ${{ secrets.AST_RND_SCANS_CLIENT_ID }}
           cx_client_secret: ${{ secrets.AST_RND_SCANS_CLIENT_SECRET }}
-          additional_params: --tags galactica-team --threshold "sast-high=1" --debug
+          additional_params: --tags galactica-team --threshold "sast-high=1"

--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -1178,7 +1178,7 @@ func validateSbomOptions(sbomOption string) (string, error) {
 	return "", errors.Errorf("invalid SBOM option: %s", sbomOption)
 }
 
-func parsePDFOptions(pdfOptions string, enginesEnabled []string) (pdfOptionsSections, pdfOptionsEngines []string, err error) {
+func parsePDFOptions(pdfOptions string, enabledEngines []string) (pdfOptionsSections, pdfOptionsEngines []string, err error) {
 	var pdfOptionsSectionsMap = map[string]string{
 		"scansummary":      "ScanSummary",
 		"executivesummary": "ExecutiveSummary",
@@ -1202,8 +1202,8 @@ func parsePDFOptions(pdfOptions string, enginesEnabled []string) (pdfOptionsSect
 		}
 	}
 	if pdfOptionsEngines == nil {
-		for _, engine := range enginesEnabled {
-			if !strings.EqualFold(engine, commonParams.APISecType) {
+		for _, engine := range enabledEngines {
+			if pdfOptionsEnginesMap[engine] != "" {
 				pdfOptionsEngines = append(pdfOptionsEngines, pdfOptionsEnginesMap[engine])
 			}
 		}

--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -1109,11 +1109,11 @@ func exportSbomResults(sbomWrapper wrappers.ResultsSbomWrapper,
 func exportPdfResults(pdfWrapper wrappers.ResultsPdfWrapper, summary *wrappers.ResultSummary, summaryRpt, formatPdfToEmail, pdfOptions string) error {
 	pdfReportsPayload := &wrappers.PdfReportsPayload{}
 	pollingResp := &wrappers.PdfPollingResponse{}
-
-	pdfOptionsSections, pdfOptionsEngines, err := validatePdfOptions(pdfOptions)
+	pdfOptionsSections, pdfOptionsEngines, err := parsePDFOptions(pdfOptions, summary.EnginesEnabled)
 	if err != nil {
 		return err
 	}
+
 	pdfReportsPayload.ReportName = reportNameScanReport
 	pdfReportsPayload.ReportType = "cli"
 	pdfReportsPayload.FileFormat = printer.FormatPDF
@@ -1178,7 +1178,7 @@ func validateSbomOptions(sbomOption string) (string, error) {
 	return "", errors.Errorf("invalid SBOM option: %s", sbomOption)
 }
 
-func validatePdfOptions(pdfOptions string) (pdfOptionsSections, pdfOptionsEngines []string, err error) {
+func parsePDFOptions(pdfOptions string, enginesEnabled []string) (pdfOptionsSections, pdfOptionsEngines []string, err error) {
 	var pdfOptionsSectionsMap = map[string]string{
 		"scansummary":      "ScanSummary",
 		"executivesummary": "ExecutiveSummary",
@@ -1199,6 +1199,13 @@ func validatePdfOptions(pdfOptions string) (pdfOptionsSections, pdfOptionsEngine
 			pdfOptionsSections = append(pdfOptionsSections, pdfOptionsSectionsMap[s])
 		} else {
 			return nil, nil, errors.Errorf("report option \"%s\" unavailable", s)
+		}
+	}
+	if pdfOptionsEngines == nil {
+		for _, engine := range enginesEnabled {
+			if !strings.EqualFold(engine, commonParams.APISecType) {
+				pdfOptionsEngines = append(pdfOptionsEngines, pdfOptionsEnginesMap[engine])
+			}
 		}
 	}
 	return pdfOptionsSections, pdfOptionsEngines, nil


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

Fix to always generate a pdf report using engines gotten on the scan if "report-pdf-options" flag value is default

![image](https://github.com/Checkmarx/ast-cli/assets/114568996/b153b0cf-fab8-4461-827f-d9c5e069b460)


### References

https://checkmarx.atlassian.net/browse/AST-30015?atlOrigin=eyJpIjoiZTgzODI3M2VmZGNkNDgxNDgxMzlmOGIwM2IyMDRiNTAiLCJwIjoiaiJ9


### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used