### PR TITLE
Fix for CLI always create a folder with the name 'project-name' and not a given project name

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1156,7 +1156,7 @@ func filterMatched(filters []string, fileName string) bool {
 	return matched
 }
 
-func runScaResolver(sourceDir, scaResolver, scaResolverParams string) error {
+func runScaResolver(sourceDir, scaResolver, scaResolverParams, projectName string) error {
 	if len(scaResolver) > 0 {
 		scaFile, err := ioutil.TempFile("", "sca")
 		scaResolverResultsFile = scaFile.Name() + ".json"
@@ -1172,7 +1172,7 @@ func runScaResolver(sourceDir, scaResolver, scaResolverParams string) error {
 			"-s",
 			sourceDir,
 			"-n",
-			commonParams.ProjectName,
+			projectName,
 			"-r",
 			scaResolverResultsFile,
 		}
@@ -1213,6 +1213,7 @@ func getUploadURLFromSource(cmd *cobra.Command, uploadsWrapper wrappers.UploadsW
 
 	sourceDirFilter, _ := cmd.Flags().GetString(commonParams.SourceDirFilterFlag)
 	userIncludeFilter, _ := cmd.Flags().GetString(commonParams.IncludeFilterFlag)
+	projectName, _ := cmd.Flags().GetString(commonParams.ProjectName)
 
 	zipFilePath, directoryPath, err := definePathForZipFileOrDirectory(cmd)
 	if err != nil {
@@ -1237,7 +1238,7 @@ func getUploadURLFromSource(cmd *cobra.Command, uploadsWrapper wrappers.UploadsW
 
 		// Make sure scaResolver only runs in sca type of scans
 		if strings.Contains(actualScanTypes, commonParams.ScaType) {
-			dirPathErr = runScaResolver(directoryPath, scaResolver, scaResolverParams)
+			dirPathErr = runScaResolver(directoryPath, scaResolver, scaResolverParams, projectName)
 			if dirPathErr != nil {
 				if unzip {
 					_ = cleanTempUnzipDirectory(directoryPath)


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Examples:

After running a scan using --sca-resolver flag and --sca-resolver-params "--log-level=Verbose"
A log is created and inside a log folder, we can find a folder that should be defined by the project name flag value. 

before fixing, inside the log folder, the folder was always created and named "project-name":
![image](https://github.com/Checkmarx/ast-cli/assets/114568996/975fadad-84fa-4337-a538-1ddd31fad3a6)

after fix:
![image](https://github.com/Checkmarx/ast-cli/assets/114568996/8b941648-4a38-4a89-b11e-c7beb4f1b8cb)

### References

https://checkmarx.atlassian.net/browse/AST-31127?atlOrigin=eyJpIjoiZmZmM2JhOGFmNDM0NGI1N2IzOWY3MTMwYWE4YWRkNjMiLCJwIjoiaiJ9

### Testing

manual tests

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used