### PR TITLE
Sast results analysis

### DIFF
--- a/internal/commands/results-prioritize.go
+++ b/internal/commands/results-prioritize.go
@@ -1,0 +1,276 @@
+package commands
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/checkmarx/ast-cli/internal/wrappers"
+)
+
+func PrioritizeSastResults(resultsModel *wrappers.ScanResultsCollection) *wrappers.ScanResultsCollection {
+	languages := GetLanguages(resultsModel)
+	queriesByLanguage := GetQueries(resultsModel, languages)
+
+	for language := range queriesByLanguage {
+		for query := range queriesByLanguage[language] {
+			resultsModel = PrioritizeSastResultsForQuery(resultsModel, language, query)
+		}
+	}
+	return resultsModel
+}
+
+func GetLanguages(resultsModel *wrappers.ScanResultsCollection) map[string]bool {
+	languages := make(map[string]bool)
+	for _, result := range resultsModel.Results {
+		languages[result.ScanResultData.LanguageName] = true
+	}
+	return languages
+}
+
+func GetQueries(resultsModel *wrappers.ScanResultsCollection, languages map[string]bool) map[string]map[string]bool {
+	queriesByLanguage := make(map[string]map[string]bool)
+	for _, result := range resultsModel.Results {
+		if _, exist := languages[result.ScanResultData.LanguageName]; !exist {
+			continue
+		}
+		if _, exist := queriesByLanguage[result.ScanResultData.LanguageName]; !exist {
+			queriesByLanguage[result.ScanResultData.LanguageName] = make(map[string]bool)
+		}
+		queriesByLanguage[result.ScanResultData.LanguageName][result.ScanResultData.QueryName] = true
+	}
+	return queriesByLanguage
+}
+
+func PrioritizeSastResultsForQuery(resultsModel *wrappers.ScanResultsCollection, language, query string) *wrappers.ScanResultsCollection {
+
+	queryResults := GetResultsForQuery(resultsModel, language, query)
+	if len(queryResults) == 0 {
+		return resultsModel
+	}
+
+	flows := buildFlows(queryResults)
+
+	subFlows := compareFlows(flows)
+
+	coveredResults := computeCoveredResults(subFlows, queryResults)
+
+	prioritizeCoveredResults(queryResults, coveredResults)
+	return resultsModel
+}
+
+func GetResultsForQuery(resultsModel *wrappers.ScanResultsCollection, language, query string) []*wrappers.ScanResult {
+	var queryResults []*wrappers.ScanResult
+	for _, result := range resultsModel.Results {
+		if result.ScanResultData.LanguageName != language || result.ScanResultData.QueryName != query {
+			continue
+		}
+		queryResults = append(queryResults, result)
+	}
+
+	sort.Slice(queryResults, func(i, j int) bool {
+		return queryResults[i].ID < queryResults[j].ID
+	})
+
+	return queryResults
+}
+
+func prioritizeCoveredResults(queryResults []*wrappers.ScanResult, coveredResults map[string]map[string]bool) {
+
+	resultsByID := make(map[string]*wrappers.ScanResult)
+	for _, result := range queryResults {
+		resultsByID[result.ID] = result
+	}
+
+	for resultID, coveredResults := range coveredResults {
+
+		if len(coveredResults) == 0 {
+			resultsByID[resultID].ScanResultData.Priority = "FIX"
+		} else {
+			resultsByID[resultID].ScanResultData.Priority = "COVERED"
+		}
+	}
+}
+
+func computeCoveredResults(subFlows map[string]*SubFlow, queryResults []*wrappers.ScanResult) map[string]map[string]bool {
+	coveredResults := make(map[string]map[string]bool)
+	for _, result := range queryResults {
+		coveredResults[result.ID] = make(map[string]bool)
+	}
+
+	sortedSubFlowIDs := sortSubFlowIDs(subFlows)
+	for _, key := range sortedSubFlowIDs {
+		sortedResults := sortSubFlowResultIDs(subFlows[key])
+		coverage := make(map[string]float64)
+		for _, resultID := range sortedResults {
+			result := getResultForID(queryResults, resultID)
+			coverage[resultID] = roundFloat(float64(len(subFlows[key].Flow))/float64(len(result.ScanResultData.Nodes)), 2)
+		}
+		maxCoverageResultID, maxCoverage := getMaxCoverage(coverage)
+
+		if maxCoverage < 0.5 {
+			continue
+		}
+		for resultID := range coverage {
+			if resultID == maxCoverageResultID {
+				continue
+			}
+			coveredResults[resultID][maxCoverageResultID] = true
+		}
+	}
+	return coveredResults
+}
+
+func getMaxCoverage(coverage map[string]float64) (string, float64) {
+	var sortedResultsIDs []string
+	for resultID := range coverage {
+		sortedResultsIDs = append(sortedResultsIDs, resultID)
+	}
+	sort.Strings(sortedResultsIDs)
+
+	maxCoverageResultID := ""
+	maxCoverage := 0.0
+	for _, resultID := range sortedResultsIDs {
+		c := coverage[resultID]
+		if c > maxCoverage {
+			maxCoverage = c
+			maxCoverageResultID = resultID
+		}
+	}
+	return maxCoverageResultID, maxCoverage
+}
+
+func roundFloat(val float64, precision uint) float64 {
+	ratio := math.Pow(10, float64(precision))
+	return math.Round(val*ratio) / ratio
+}
+
+func getResultForID(queryResults []*wrappers.ScanResult, resultID string) *wrappers.ScanResult {
+	for _, result := range queryResults {
+		if result.ID == resultID {
+			return result
+		}
+	}
+	return nil
+}
+
+func sortSubFlowIDs(subFlows map[string]*SubFlow) []string {
+	var subFlowIDs []string
+	for key := range subFlows {
+		subFlowIDs = append(subFlowIDs, key)
+	}
+	sort.Strings(subFlowIDs)
+	return subFlowIDs
+}
+
+func sortSubFlowResultIDs(subFlow *SubFlow) []string {
+	var results []string
+	for result := range subFlow.Results {
+		results = append(results, result)
+	}
+	sort.Strings(results)
+	return results
+}
+
+func buildFlows(queryResults []*wrappers.ScanResult) map[string][]string {
+	flowsByResult := make(map[string][]string)
+	for _, result := range queryResults {
+		var resultNodes []string
+		for _, node := range result.ScanResultData.Nodes {
+			nodeStr := fmt.Sprintf("%s:%d:%d", node.FileName, node.Line, node.Column)
+			resultNodes = append(resultNodes, nodeStr)
+		}
+		flowsByResult[result.ID] = resultNodes
+	}
+	return flowsByResult
+}
+
+type SubFlow struct {
+	ShaOne  string
+	Flow    []string
+	Results map[string]bool
+}
+
+func compareFlows(flows map[string][]string) map[string]*SubFlow {
+	subFlows := make(map[string]*SubFlow)
+	comparedFlows := make(map[string]bool)
+	for r1, f1 := range flows {
+		for r2, f2 := range flows {
+			if r1 == r2 {
+				continue
+			}
+			key := GetKey(r1, r2)
+			if _, exist := comparedFlows[key]; exist {
+				continue
+			}
+			comparedFlows[key] = true
+
+			// compute the subflow of f1 and f2
+			exist, sf := computeSubFlow(f1, f2)
+			if !exist {
+				continue
+			}
+			if _, exist := subFlows[sf.ShaOne]; !exist {
+				sf.Results = make(map[string]bool)
+				subFlows[sf.ShaOne] = sf
+			}
+			subFlows[sf.ShaOne].Results[r1] = true
+			subFlows[sf.ShaOne].Results[r2] = true
+
+		}
+	}
+	return subFlows
+}
+
+func GetKey(r1, r2 string) string {
+	if r1 <= r2 {
+		return r1 + "," + r2
+	} else {
+		return r2 + "," + r1
+	}
+}
+
+func computeSubFlow(f1, f2 []string) (bool, *SubFlow) {
+	var subFlow []string
+	for i1 := 0; i1 < len(f1); {
+		for i2 := 0; i2 < len(f2); {
+			if f1[i1] == f2[i2] {
+				subFlow = append(subFlow, f1[i1])
+				i1++
+				i2++
+			} else {
+				if len(subFlow) > 0 {
+					break
+				}
+				i2++
+			}
+		}
+		if len(subFlow) > 0 {
+			break
+		}
+		i1++
+	}
+	if len(subFlow) == 0 {
+		return false, nil
+	}
+	sha1String := getSha1String(subFlow)
+	return true, &SubFlow{sha1String, subFlow, nil}
+}
+
+func getSha1String(lines []string) string {
+	h := sha1.New()
+
+	// Write the bytes of the input string into the hash
+	h.Write([]byte(strings.Join(lines, "")))
+
+	// Get the final hash result as a byte slice
+	bs := h.Sum(nil)
+
+	// Convert the byte slice to a hexadecimal string
+	sha1String := hex.EncodeToString(bs)
+
+	return sha1String
+}

--- a/internal/commands/results-prioritize.go
+++ b/internal/commands/results-prioritize.go
@@ -46,7 +46,6 @@ func GetQueries(resultsModel *wrappers.ScanResultsCollection, languages map[stri
 }
 
 func PrioritizeSastResultsForQuery(resultsModel *wrappers.ScanResultsCollection, language, query string) *wrappers.ScanResultsCollection {
-
 	queryResults := GetResultsForQuery(resultsModel, language, query)
 	if len(queryResults) == 0 {
 		return resultsModel
@@ -79,14 +78,12 @@ func GetResultsForQuery(resultsModel *wrappers.ScanResultsCollection, language, 
 }
 
 func prioritizeCoveredResults(queryResults []*wrappers.ScanResult, coveredResults map[string]map[string]bool) {
-
 	resultsByID := make(map[string]*wrappers.ScanResult)
 	for _, result := range queryResults {
 		resultsByID[result.ID] = result
 	}
 
 	for resultID, coveredResults := range coveredResults {
-
 		if len(coveredResults) == 0 {
 			resultsByID[resultID].ScanResultData.Priority = "FIX"
 		} else {
@@ -124,15 +121,15 @@ func computeCoveredResults(subFlows map[string]*SubFlow, queryResults []*wrapper
 	return coveredResults
 }
 
-func getMaxCoverage(coverage map[string]float64) (string, float64) {
+func getMaxCoverage(coverage map[string]float64) (maxCoverageResultID string, maxCoverage float64) {
 	var sortedResultsIDs []string
 	for resultID := range coverage {
 		sortedResultsIDs = append(sortedResultsIDs, resultID)
 	}
 	sort.Strings(sortedResultsIDs)
 
-	maxCoverageResultID := ""
-	maxCoverage := 0.0
+	maxCoverageResultID = ""
+	maxCoverage = 0.0
 	for _, resultID := range sortedResultsIDs {
 		c := coverage[resultID]
 		if c > maxCoverage {
@@ -219,7 +216,6 @@ func compareFlows(flows map[string][]string) map[string]*SubFlow {
 			}
 			subFlows[sf.ShaOne].Results[r1] = true
 			subFlows[sf.ShaOne].Results[r2] = true
-
 		}
 	}
 	return subFlows
@@ -228,9 +224,8 @@ func compareFlows(flows map[string][]string) map[string]*SubFlow {
 func GetKey(r1, r2 string) string {
 	if r1 <= r2 {
 		return r1 + "," + r2
-	} else {
-		return r2 + "," + r1
 	}
+	return r2 + "," + r1
 }
 
 func computeSubFlow(f1, f2 []string) (bool, *SubFlow) {

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -134,6 +134,7 @@ const (
 	ExploitablePathFlag      = "sca-exploitable-path"
 	LastSastScanTime         = "sca-last-sast-scan-time"
 	ProjecPrivatePackageFlag = "project-private-package"
+	PrioritizeSastFlag       = "prioritize-sast"
 
 	ScaPrivatePackageVersionFlag = "sca-private-package-version"
 

--- a/internal/wrappers/results-json.go
+++ b/internal/wrappers/results-json.go
@@ -93,6 +93,7 @@ type ScanResultData struct {
 	Group                string                   `json:"group,omitempty"`
 	ResultHash           string                   `json:"resultHash,omitempty"`
 	LanguageName         string                   `json:"languageName,omitempty"`
+	Priority             string                   `json:"priority,omitempty"`
 	Description          string                   `json:"description,omitempty"`
 	Nodes                []*ScanResultNode        `json:"nodes,omitempty"`
 	PackageData          []*ScanResultPackageData `json:"packageData,omitempty"`


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

Many SAST results share matching sub-flows, which as a result share the same fix. This feature locates these sub-flows and filters out COVERED results that don't need to be fixed since a fix for covering results will fix them as well. This feature is activated by `$ cx results show --scan-id <scan-id> --prioritize-sast`. Activating prioritization will populate a `priority` field in the JSON results file for every SAST `data` structure with the values `FIX` for results that need to be fixed, and `COVERED` for results that do not need to be fixed.

### References


### Testing

Added unit tests that execute the prioritization logic

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used