### PR TITLE
AST-36339 | enable Ai Guided Remediation only if the tenant has permission

### DIFF
--- a/internal/commands/chat.go
+++ b/internal/commands/chat.go
@@ -1,21 +1,43 @@
 package commands
 
 import (
+	"strconv"
+
 	"github.com/checkmarx/ast-cli/internal/wrappers"
 	"github.com/spf13/cobra"
 )
 
 const ConversationIDErrorFormat = "Invalid conversation ID %s"
+const AiGuidedRemediationEnabled = "scan.config.plugins.aiGuidedRemediation"
 
-func NewChatCommand(chatWrapper wrappers.ChatWrapper) *cobra.Command {
+func NewChatCommand(chatWrapper wrappers.ChatWrapper, tenantWrapper wrappers.TenantConfigurationWrapper) *cobra.Command {
 	chatCmd := &cobra.Command{
 		Use:   "chat",
 		Short: "Chat with OpenAI models",
 		Long:  "Chat with OpenAI models regarding KICS or SAST results",
 	}
-	chatKicsCmd := ChatKicsSubCommand(chatWrapper)
-	chatSastCmd := ChatSastSubCommand(chatWrapper)
-
-	chatCmd.AddCommand(chatKicsCmd, chatSastCmd)
+	chatCmd.AddCommand(ChatKicsSubCommand(chatWrapper))
+	if aiGuidedRemediationEnabled(tenantWrapper) {
+		chatCmd.AddCommand(ChatSastSubCommand(chatWrapper))
+	}
 	return chatCmd
+}
+
+func aiGuidedRemediationEnabled(tenantWrapper wrappers.TenantConfigurationWrapper) bool {
+	tenantConfigurationResponse, errorModel, err := tenantWrapper.GetTenantConfiguration()
+	if err != nil {
+		return false
+	}
+	if errorModel != nil {
+		return false
+	}
+	if tenantConfigurationResponse != nil {
+		for _, resp := range *tenantConfigurationResponse {
+			if resp.Key == AiGuidedRemediationEnabled {
+				isEnabled, _ := strconv.ParseBool(resp.Value)
+				return isEnabled
+			}
+		}
+	}
+	return false
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -191,7 +191,7 @@ func NewAstCLI(
 	configCmd := util.NewConfigCommand()
 	triageCmd := NewResultsPredicatesCommand(resultsPredicatesWrapper)
 
-	chatCmd := NewChatCommand(chatWrapper)
+	chatCmd := NewChatCommand(chatWrapper, tenantWrapper)
 
 	rootCmd.AddCommand(
 		scanCmd,


### PR DESCRIPTION
### Description

> chat command for sast results should validate CxOne AI Guided Remediation permission

### References

> https://checkmarx.atlassian.net/browse/AST-36339

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used