### PR TITLE
CLI | Fast Scan configuration in SAST scanner (AST-37706)

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -522,6 +522,12 @@ func scanCreateSubCommand(
 		[]string{},
 		commonParams.KicsPlatformsFlagUsage,
 	)
+	createScanCmd.PersistentFlags().Bool(
+		commonParams.SastFastScanFlag,
+		false,
+		"Enable SAST Fast Scan configuration",
+	)
+
 	createScanCmd.PersistentFlags().StringSlice(
 		commonParams.IacsPlatformsFlag,
 		[]string{},
@@ -933,7 +939,9 @@ func addSastScan(cmd *cobra.Command, resubmitConfig []wrappers.Config) map[strin
 		sastConfig := wrappers.SastConfig{}
 		sastMapConfig[resultsMapType] = commonParams.SastType
 		incrementalVal, _ := cmd.Flags().GetBool(commonParams.IncrementalSast)
+		fastScan, _ := cmd.Flags().GetBool(commonParams.SastFastScanFlag)
 		sastConfig.Incremental = strconv.FormatBool(incrementalVal)
+		sastConfig.FastScanMode = strconv.FormatBool(fastScan)
 		sastConfig.PresetName, _ = cmd.Flags().GetString(commonParams.PresetName)
 		sastConfig.Filter, _ = cmd.Flags().GetString(commonParams.SastFilterFlag)
 		for _, config := range resubmitConfig {

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -555,7 +555,7 @@ func TestAddScaScan(t *testing.T) {
 	}
 }
 
-func TestAddSastScanWithFastScan(t *testing.T) {
+func TestAddSastScan_WithFastScanFlag_ShouldPass(t *testing.T) {
 	var resubmitConfig []wrappers.Config
 
 	cmdCommand := &cobra.Command{

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -555,6 +555,54 @@ func TestAddScaScan(t *testing.T) {
 	}
 }
 
+func TestAddSastScanWithFastScan(t *testing.T) {
+	var resubmitConfig []wrappers.Config
+
+	cmdCommand := &cobra.Command{
+		Use:   "scan",
+		Short: "Scan a project",
+		Long:  `Scan a project with SAST fast scan configuration`,
+	}
+
+	cmdCommand.PersistentFlags().String(commonParams.PresetName, "", "Preset name")
+	cmdCommand.PersistentFlags().String(commonParams.SastFilterFlag, "", "Filter for SAST scan")
+	cmdCommand.PersistentFlags().Bool(commonParams.IncrementalSast, false, "Incremental SAST scan")
+	cmdCommand.PersistentFlags().Bool(commonParams.SastFastScanFlag, false, "Enable SAST Fast Scan")
+
+	_ = cmdCommand.Execute()
+
+	_ = cmdCommand.Flags().Set(commonParams.PresetName, "test")
+	_ = cmdCommand.Flags().Set(commonParams.SastFilterFlag, "test")
+	_ = cmdCommand.Flags().Set(commonParams.IncrementalSast, "true")
+	_ = cmdCommand.Flags().Set(commonParams.SastFastScanFlag, "true")
+
+	result := addSastScan(cmdCommand, resubmitConfig)
+
+	sastConfig := wrappers.SastConfig{
+		PresetName:   "test",
+		Filter:       "test",
+		Incremental:  "true",
+		FastScanMode: "true",
+	}
+	sastMapConfig := make(map[string]interface{})
+	sastMapConfig[resultsMapType] = commonParams.SastType
+	sastMapConfig[resultsMapValue] = &sastConfig
+
+	if !reflect.DeepEqual(result, sastMapConfig) {
+		t.Errorf("Expected %+v, but got %+v", sastMapConfig, result)
+	}
+}
+
+func TestCreateScanWithFastScanFlagIncorrectCase(t *testing.T) {
+	baseArgs := []string{"scan", "create", "--project-name", "MOCK", "--branch", "b", "--scan-types", "sast", "--file-source", "."}
+
+	err := execCmdNotNilAssertion(t, append(baseArgs, "--SAST-FAST-SCAN", "true")...)
+	assert.ErrorContains(t, err, "unknown flag: --SAST-FAST-SCAN", err.Error())
+
+	err = execCmdNotNilAssertion(t, append(baseArgs, "--Sast-Fast-Scan", "true")...)
+	assert.ErrorContains(t, err, "unknown flag: --Sast-Fast-Scan", err.Error())
+}
+
 func TestAddSastScan(t *testing.T) {
 	var resubmitConfig []wrappers.Config
 

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -626,9 +626,10 @@ func TestAddSastScan(t *testing.T) {
 	result := addSastScan(cmdCommand, resubmitConfig)
 
 	sastConfig := wrappers.SastConfig{
-		PresetName:  "test",
-		Filter:      "test",
-		Incremental: "true",
+		PresetName:   "test",
+		Filter:       "test",
+		Incremental:  "true",
+		FastScanMode: "true",
 	}
 	sastMapConfig := make(map[string]interface{})
 	sastMapConfig[resultsMapType] = commonParams.SastType

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -615,7 +615,7 @@ func TestAddSastScan(t *testing.T) {
 	cmdCommand.PersistentFlags().String(commonParams.PresetName, "", "Preset name")
 	cmdCommand.PersistentFlags().String(commonParams.SastFilterFlag, "", "Filter for SAST scan")
 	cmdCommand.PersistentFlags().Bool(commonParams.IncrementalSast, false, "Incremental SAST scan")
-	cmdCommand.PersistentFlags().Bool(commonParams.SastFastScanFlag, false, "Enable SAST Fast Scan")
+	cmdCommand.PersistentFlags().Bool(commonParams.SastFastScanFlag, true, "Enable SAST Fast Scan")
 
 	_ = cmdCommand.Execute()
 

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -615,6 +615,7 @@ func TestAddSastScan(t *testing.T) {
 	cmdCommand.PersistentFlags().String(commonParams.PresetName, "", "Preset name")
 	cmdCommand.PersistentFlags().String(commonParams.SastFilterFlag, "", "Filter for SAST scan")
 	cmdCommand.PersistentFlags().Bool(commonParams.IncrementalSast, false, "Incremental SAST scan")
+	cmdCommand.PersistentFlags().Bool(commonParams.SastFastScanFlag, false, "Enable SAST Fast Scan")
 
 	_ = cmdCommand.Execute()
 

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -56,6 +56,7 @@ const (
 	TimeoutFlag                   = "timeout"
 	TimeoutFlagUsage              = "Timeout for network activity, (default 5 seconds)"
 	NtlmProxyDomainFlag           = "proxy-ntlm-domain"
+	SastFastScanFlag              = "sast-fast-scan"
 	NtlmProxyDomainFlagUsage      = "Window domain when using NTLM proxy"
 	BaseURIFlagUsage              = "The base system URI"
 	BaseAuthURIFlag               = "base-auth-uri"

--- a/internal/wrappers/scans.go
+++ b/internal/wrappers/scans.go
@@ -126,6 +126,7 @@ type SastConfig struct {
 	EngineVerbose string `json:"engineVerbose,omitempty"`
 	LanguageMode  string `json:"languageMode,omitempty"`
 	PresetName    string `json:"presetName,omitempty"`
+	FastScanMode  string `json:"fastScanMode,omitempty"`
 }
 
 type KicsConfig struct {

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -126,6 +126,19 @@ func TestScansE2E(t *testing.T) {
 	assert.Equal(t, len(glob), 0, "Zip file not removed")
 }
 
+func TestFastScan(t *testing.T) {
+	projectName := getProjectNameForScanTests()
+	// Create a scan
+	scanID, projectID := createScanWithFastScan(t, Dir, projectName, map[string]string{})
+	defer deleteProject(t, projectID)
+	executeScanAssertions(t, projectID, scanID, map[string]string{})
+}
+
+func createScanWithFastScan(t *testing.T, source string, name string, tags map[string]string) (string, string) {
+	args := append(getCreateArgsWithName(source, tags, name, "sast"), flag(params.SastFastScanFlag))
+	return executeCreateScan(t, args)
+}
+
 func TestScansUpdateProjectGroups(t *testing.T) {
 	scanID, projectID := executeCreateScan(t, getCreateArgs(Zip, Tags, "sast"))
 	response := listScanByID(t, scanID)


### PR DESCRIPTION
### Description

> Create --sast-fast-scan flag in the scan create command with the value true/false

### References

>https://checkmarx.atlassian.net/browse/AST-37706

> https://checkmarx.atlassian.net/browse/AST-36800

### Testing

> Added unit and integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used