### PR TITLE
Fix project association polling issue (AST-40286)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
       APPLE_DEVELOPER_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
@@ -60,19 +60,9 @@ jobs:
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           brew --version
       - name: Install gon
-        run: |
-          brew install Bearer/tap/gon
-      - name: Install and start docker
-        if: inputs.dev == false
-        run: |
-          brew install docker
-          colima start
-          sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
-      - name: Test docker
-        if: inputs.dev == false
-        run: |
-          docker version
-          docker info
+        run: brew install Bearer/tap/gon
+      - name: install docker
+        run: brew install docker
       - name: Login to Docker Hub
         if: inputs.dev == false
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 #v1

--- a/internal/commands/.scripts/integration_up.sh
+++ b/internal/commands/.scripts/integration_up.sh
@@ -13,7 +13,7 @@ rm -rf ScaResolver-linux64.tar.gz
 go test \
   -tags integration \
   -v \
-  -timeout 90m \
+  -timeout 210m \
   -coverpkg github.com/checkmarx/ast-cli/internal/commands,github.com/checkmarx/ast-cli/internal/wrappers \
   -coverprofile cover.out \
   github.com/checkmarx/ast-cli/test/integration

--- a/internal/commands/.scripts/up.sh
+++ b/internal/commands/.scripts/up.sh
@@ -4,4 +4,4 @@ wget https://sca-downloads.s3.amazonaws.com/cli/latest/ScaResolver-linux64.tar.g
 tar -xzvf ScaResolver-linux64.tar.gz -C /tmp
 rm -rf ScaResolver-linux64.tar.gz
 # ignore mock and wrappers packages, as they checked by integration tests
-go test $(go list ./... | grep -v "mock" | grep -v "wrappers" | grep -v "bitbucketserver" | grep -v "logger") -timeout 720.000s -coverprofile cover.out
+go test $(go list ./... | grep -v "mock" | grep -v "wrappers" | grep -v "bitbucketserver" | grep -v "logger") -timeout 940.000s -coverprofile cover.out

--- a/internal/commands/.scripts/up.sh
+++ b/internal/commands/.scripts/up.sh
@@ -4,4 +4,4 @@ wget https://sca-downloads.s3.amazonaws.com/cli/latest/ScaResolver-linux64.tar.g
 tar -xzvf ScaResolver-linux64.tar.gz -C /tmp
 rm -rf ScaResolver-linux64.tar.gz
 # ignore mock and wrappers packages, as they checked by integration tests
-go test $(go list ./... | grep -v "mock" | grep -v "wrappers" | grep -v "bitbucketserver" | grep -v "logger") -coverprofile cover.out
+go test $(go list ./... | grep -v "mock" | grep -v "wrappers" | grep -v "bitbucketserver" | grep -v "logger") -timeout 720.000s -coverprofile cover.out

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -694,6 +694,7 @@ func verifyApplicationAssociationDone(applicationID []string, projectID string, 
 		} else if time.Now().After(timeout) {
 			return errors.Errorf("%s: %v", failedProjectApplicationAssociation, "timeout of 2 min for association")
 		}
+		time.Sleep(2 * time.Second)
 		logger.PrintIfVerbose("application association polling - waiting for associating to complete")
 	}
 

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -675,7 +675,7 @@ func createProject(
 	return projectID, err
 }
 
-func verifyApplicationAssociationDone(applicationName string, projectID string, applicationsWrapper wrappers.ApplicationsWrapper) error {
+func verifyApplicationAssociationDone(applicationName, projectID string, applicationsWrapper wrappers.ApplicationsWrapper) error {
 	var applicationRes *wrappers.ApplicationsResponseModel
 	var err error
 	params := make(map[string]string)
@@ -695,7 +695,7 @@ func verifyApplicationAssociationDone(applicationName string, projectID string, 
 		} else if time.Now().After(timeout) {
 			return errors.Errorf("%s: %v", failedProjectApplicationAssociation, "timeout of 2 min for association")
 		}
-		time.Sleep(2 * time.Second)
+		time.Sleep(time.Second)
 		logger.PrintIfVerbose("application association polling - waiting for associating to complete")
 	}
 

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -699,7 +699,7 @@ func verifyApplicationAssociationDone(applicationName, projectID string, applica
 		logger.PrintIfVerbose("application association polling - waiting for associating to complete")
 	}
 
-	return nil
+	return errors.Errorf("%s: %v", failedProjectApplicationAssociation, "timeout of 2 min for association")
 }
 
 func updateProject(

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -636,6 +636,7 @@ func createProject(
 	applicationID []string,
 ) (string, error) {
 	projectGroups, _ := cmd.Flags().GetString(commonParams.ProjectGroupList)
+	applicationName, _ := cmd.Flags().GetString(commonParams.ApplicationName)
 	projectTags, _ := cmd.Flags().GetString(commonParams.ProjectTagList)
 	projectPrivatePackage, _ := cmd.Flags().GetString(commonParams.ProjecPrivatePackageFlag)
 
@@ -657,8 +658,8 @@ func createProject(
 	if err == nil {
 		projectID = resp.ID
 
-		if len(applicationID) > 0 {
-			err = verifyApplicationAssociationDone(applicationID, projectID, applicationsWrapper)
+		if applicationName != "" || len(applicationID) > 0 {
+			err = verifyApplicationAssociationDone(applicationName, projectID, applicationsWrapper)
 			if err != nil {
 				return projectID, err
 			}
@@ -674,11 +675,11 @@ func createProject(
 	return projectID, err
 }
 
-func verifyApplicationAssociationDone(applicationID []string, projectID string, applicationsWrapper wrappers.ApplicationsWrapper) error {
+func verifyApplicationAssociationDone(applicationName string, projectID string, applicationsWrapper wrappers.ApplicationsWrapper) error {
 	var applicationRes *wrappers.ApplicationsResponseModel
 	var err error
 	params := make(map[string]string)
-	params["id"] = applicationID[0]
+	params["name"] = applicationName
 
 	logger.PrintIfVerbose("polling application until project association done or timeout of 2 min")
 	var timeoutDuration = 2 * time.Minute
@@ -716,6 +717,7 @@ func updateProject(
 	var projModel = wrappers.Project{}
 	projectGroups, _ := cmd.Flags().GetString(commonParams.ProjectGroupList)
 	projectTags, _ := cmd.Flags().GetString(commonParams.ProjectTagList)
+	applicationName, _ := cmd.Flags().GetString(commonParams.ApplicationName)
 	projectPrivatePackage, _ := cmd.Flags().GetString(commonParams.ProjecPrivatePackageFlag)
 	for i := 0; i < len(resp.Projects); i++ {
 		if resp.Projects[i].Name == projectName {
@@ -762,8 +764,8 @@ func updateProject(
 		return "", errors.Errorf("%s: %v", failedUpdatingProj, err)
 	}
 
-	if len(applicationID) > 0 {
-		err = verifyApplicationAssociationDone(applicationID, projectID, applicationsWrapper)
+	if applicationName != "" || len(applicationID) > 0 {
+		err = verifyApplicationAssociationDone(applicationName, projectID, applicationsWrapper)
 		if err != nil {
 			return projectID, err
 		}

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -447,6 +447,7 @@ func getClientCredentials(accessKeyID, accessKeySecret, astAPKey, authURI string
 
 func getClientCredentialsFromCache(tokenExpirySeconds int) string {
 	logger.PrintIfVerbose("Checking cache for API access token.")
+
 	expired := time.Since(cachedAccessTime) > time.Duration(tokenExpirySeconds-expiryGraceSeconds)*time.Second
 	if !expired {
 		logger.PrintIfVerbose("Using cached API access token!")

--- a/internal/wrappers/mock/application-mock.go
+++ b/internal/wrappers/mock/application-mock.go
@@ -28,7 +28,7 @@ func (a ApplicationsMockWrapper) Get(params map[string]string) (*wrappers.Applic
 		Name:        "MOCK",
 		Description: "This is a mock application",
 		Criticality: 2,
-		ProjectIds:  []string{"ProjectID1", "ProjectID2"},
+		ProjectIds:  []string{"ProjectID1", "ProjectID2", "MOCK"},
 		CreatedAt:   time.Now(),
 	}
 


### PR DESCRIPTION
### Description

> Fix project association polling issue

### References

> https://checkmarx.atlassian.net/jira/software/c/projects/AST/boards/471/backlog?selectedIssue=AST-40286

### Testing

> manual testing done, unit & integration are verifying association, but without new access management, it'll be in unit & integration tests after FF will be open

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used