### PR TITLE
Filtering out default IDE folders in a project for a scan (AST-34978)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/checkmarx/ast-cli
 
-go 1.22.2
+go 1.22.3
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -934,7 +934,7 @@ func compressFolder(sourceDir, filter, userIncludeFilter, scaResolver string) (s
 		return "", errors.Wrapf(err, "Cannot source code temp file.")
 	}
 	zipWriter := zip.NewWriter(outputFile)
-	err = addDirFiles(zipWriter, "", sourceDir, getUserFilters(filter), getIncludeFilters(userIncludeFilter))
+	err = addDirFiles(zipWriter, "", sourceDir, getExcludeFilters(filter), getIncludeFilters(userIncludeFilter))
 	if err != nil {
 		return "", err
 	}
@@ -958,11 +958,11 @@ func compressFolder(sourceDir, filter, userIncludeFilter, scaResolver string) (s
 }
 
 func getIncludeFilters(userIncludeFilter string) []string {
-	return buildFilters(commonParams.BaseFilters, userIncludeFilter)
+	return buildFilters(commonParams.BaseIncludeFilters, userIncludeFilter)
 }
 
-func getUserFilters(filterStr string) []string {
-	return buildFilters(nil, filterStr)
+func getExcludeFilters(userExcludeFilter string) []string {
+	return buildFilters(commonParams.BaseExcludeFilters, userExcludeFilter)
 }
 
 func buildFilters(base []string, extra string) []string {
@@ -1064,22 +1064,34 @@ func handleDir(
 		newParent, newBase := GetNewParentAndBase(parentDir, file, baseDir)
 		return addDirFilesIgnoreFilter(zipWriter, newBase, newParent)
 	}
-	// Check if the folder is excluded
-	for _, filter := range filters {
-		if filter[0] == '!' {
-			filterStr := strings.TrimSuffix(filepath.ToSlash(filter[1:]), "/")
-			match, err := path.Match(filterStr, file.Name())
-			if err != nil {
-				return err
-			}
-			if match {
-				logger.PrintIfVerbose("Excluded: " + parentDir + file.Name() + "/")
-				return nil
-			}
-		}
+
+	isFiltered, err := isDirFiltered(file.Name(), filters)
+	if err != nil {
+		return err
+	}
+	if isFiltered {
+		logger.PrintIfVerbose("Excluded: " + parentDir + file.Name() + "/")
+		return nil
 	}
 	newParent, newBase := GetNewParentAndBase(parentDir, file, baseDir)
 	return addDirFiles(zipWriter, newBase, newParent, filters, includeFilters)
+}
+
+func isDirFiltered(filename string, filters []string) (bool, error) {
+	for _, filter := range filters {
+		if filter[0] == '!' {
+			filterStr := strings.TrimSuffix(filepath.ToSlash(filter[1:]), "/")
+			match, err := path.Match(filterStr, filename)
+			if err != nil {
+				return false, err
+			}
+			if match {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
 }
 
 func GetNewParentAndBase(parentDir string, file fs.FileInfo, baseDir string) (newParent, newBase string) {

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -715,14 +715,58 @@ func TestCreateScanProjectTagsCheckResendToScan(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func TestCreateScan_WhenFolderIsExcluded_ReturnIsFilteredTrue(t *testing.T) {
-	res, _ := isDirFiltered(".vs", commonParams.BaseExcludeFilters)
-	assert.Equal(t, res, true)
-}
-
-func TestCreateScan_WhenFolderIsNotExcluded_ReturnIsFilteredFalse(t *testing.T) {
-	res, _ := isDirFiltered("some-folder-name", commonParams.BaseExcludeFilters)
-	assert.Equal(t, res, false)
+func Test_isDirFiltered(t *testing.T) {
+	type args struct {
+		filename string
+		filters  []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "WhenUserDefinedExcludedFolder_ReturnIsFilteredTrue",
+			args: args{
+				filename: "user-folder-to-exclude",
+				filters:  append(commonParams.BaseExcludeFilters, "!user-folder-to-exclude"),
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "WhenFolderIsNotExcluded_ReturnIsFilteredFalse",
+			args: args{
+				filename: "some-folder-name",
+				filters:  commonParams.BaseExcludeFilters,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "WhenDefaultFolderIsExcluded_ReturnIsFilteredTrue",
+			args: args{
+				filename: ".vs",
+				filters:  commonParams.BaseExcludeFilters,
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		ttt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isDirFiltered(ttt.args.filename, ttt.args.filters)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("isDirFiltered() error = %v, wantErr %v", err, ttt.wantErr)
+				return
+			}
+			if got != ttt.want {
+				t.Errorf("isDirFiltered() got = %v, want %v", got, ttt.want)
+			}
+		})
+	}
 }
 
 func Test_parseThresholdLimit(t *testing.T) {

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -715,6 +715,16 @@ func TestCreateScanProjectTagsCheckResendToScan(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestCreateScan_WhenFolderIsExcluded_ReturnIsFilteredTrue(t *testing.T) {
+	res, _ := isDirFiltered(".vs", commonParams.BaseExcludeFilters)
+	assert.Equal(t, res, true)
+}
+
+func TestCreateScan_WhenFolderIsNotExcluded_ReturnIsFilteredFalse(t *testing.T) {
+	res, _ := isDirFiltered("some-folder-name", commonParams.BaseExcludeFilters)
+	assert.Equal(t, res, false)
+}
+
 func Test_parseThresholdLimit(t *testing.T) {
 	type args struct {
 		limit string

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -736,6 +736,15 @@ func Test_isDirFiltered(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "WhenUserDefinedExcludedFolder_DoesNotAffectOtherFolders_ReturnIsFilteredFalse",
+			args: args{
+				filename: "some-folder",
+				filters:  append(commonParams.BaseExcludeFilters, "!exclude-other-folder"),
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
 			name: "WhenFolderIsNotExcluded_ReturnIsFilteredFalse",
 			args: args{
 				filename: "some-folder-name",

--- a/internal/params/filters.go
+++ b/internal/params/filters.go
@@ -1,6 +1,6 @@
 package params
 
-var BaseFilters = []string{
+var BaseIncludeFilters = []string{
 	"*.javasln",
 	"*.project",
 	"*.java",
@@ -133,6 +133,12 @@ var BaseFilters = []string{
 	"Podfile.lock",
 	"*.cmp",
 	"Directory.Packages.props",
+}
+
+var BaseExcludeFilters = []string{
+	"!.vs",
+	"!.vscode",
+	"!.idea",
 }
 
 var KicsBaseFilters = []string{


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Filtering out folders generated by IDEs (.vs, .vscode and .idea) by default when triggering a scan.

### References

> https://checkmarx.atlassian.net/browse/AST-34978

### Testing

> Added unit tests to check the behavior of filtering out the default folder.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used