### PR TITLE
Dont Call SCA for Threshold AST-42820

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/checkmarx/ast-cli
 
-go 1.22.2
+go 1.22.3
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1437,7 +1437,7 @@ func runCreateScanCommand(
 				return err
 			}
 
-			err = applyThreshold(cmd, resultsWrapper, scanResponseModel, thresholdMap)
+			err = applyThreshold(resultsWrapper, scanResponseModel, thresholdMap)
 			if err != nil {
 				return err
 			}
@@ -1676,7 +1676,6 @@ func createReportsAfterScan(
 }
 
 func applyThreshold(
-	cmd *cobra.Command,
 	resultsWrapper wrappers.ResultsWrapper,
 	scanResponseModel *wrappers.ScanResponseModel,
 	thresholdMap map[string]int,
@@ -1772,7 +1771,7 @@ func getSummaryThresholdMap(resultsWrapper wrappers.ResultsWrapper, scan *wrappe
 	map[string]int,
 	error,
 ) {
-	results, err := ReadResults(resultsWrapper, scan, make(map[string]string))
+	results, err := ReadResults(resultsWrapper, scan, make(map[string]string), true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -127,6 +127,10 @@ func TestCreateScan(t *testing.T) {
 	execCmdNilAssertion(t, "scan", "create", "--project-name", "MOCK", "-s", dummyRepo, "-b", "dummy_branch")
 }
 
+func TestCreateScanWithThreshold_ShouldSuccess(t *testing.T) {
+	execCmdNilAssertion(t, "scan", "create", "--project-name", "MOCK", "-s", dummyRepo, "-b", "dummy_branch", "--scan-types", "sast", "--threshold", "sca-low=1 ; sast-medium=2")
+}
+
 func TestScanCreate_ExistingApplicationAndProject_CreateProjectUnderApplicationSuccessfully(t *testing.T) {
 	execCmdNilAssertion(t, "scan", "create", "--project-name", "MOCK", "--application-name", "MOCK", "-s", dummyRepo, "-b", "dummy_branch")
 }
@@ -494,6 +498,17 @@ func Test_parseThresholdSuccess(t *testing.T) {
 	want := make(map[string]int)
 	want["iac-security-low"] = 1
 	threshold := " KICS - LoW=1"
+	if got := parseThreshold(threshold); !reflect.DeepEqual(got, want) {
+		t.Errorf("parseThreshold() = %v, want %v", got, want)
+	}
+}
+
+func Test_parseThresholdsSuccess(t *testing.T) {
+	want := make(map[string]int)
+	want["sast-high"] = 1
+	want["sast-medium"] = 1
+	want["sca-high"] = 1
+	threshold := "sast-high=1; sast-medium=1; sca-high=1"
 	if got := parseThreshold(threshold); !reflect.DeepEqual(got, want) {
 		t.Errorf("parseThreshold() = %v, want %v", got, want)
 	}

--- a/test/integration/root_test.go
+++ b/test/integration/root_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/test/integration/root_test.go
+++ b/test/integration/root_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package integration
 
 import (
@@ -49,6 +47,11 @@ func TestMain(m *testing.M) {
 	//deleteScanAndProject()
 	log.Println("CLI integration tests done")
 	os.Exit(exitVal)
+}
+
+func TestRootVersion(t *testing.T) {
+	testInstance = t
+	executeCmdNilAssertion(t, "test root version", "version")
 }
 
 // Create or return a scan to be shared between tests


### PR DESCRIPTION
### Description

> SCA have a different endpoint for the scan results, don't make this call for threshold

### References

> https://checkmarx.atlassian.net/browse/AST-42820?atlOrigin=eyJpIjoiMWVhOGFkZDJiNWFkNDE5NjlhN2NmMzIwZDc5MDc4NzQiLCJwIjoiaiJ9

### Testing

> Add tests + manual

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used