### PR TITLE
AST-42743 Update results-pdf timeout to 7 minutes

### DIFF
--- a/internal/wrappers/results-pdf-http.go
+++ b/internal/wrappers/results-pdf-http.go
@@ -49,7 +49,7 @@ func NewResultsPdfReportsHTTPWrapper(path string) ResultsPdfWrapper {
 }
 
 func (r *PdfHTTPWrapper) GeneratePdfReport(payload *PdfReportsPayload) (*PdfReportsResponse, *WebError, error) {
-	clientTimeout := 7
+	clientTimeout := viper.GetUint(commonParams.ClientTimeoutKey)
 	params, err := json.Marshal(payload)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "Failed to parse request body")
@@ -107,7 +107,7 @@ func (r *PdfHTTPWrapper) CheckPdfReportStatus(reportID string) (*PdfPollingRespo
 }
 
 func (r *PdfHTTPWrapper) DownloadPdfReport(reportID, targetFile string) error {
-	clientTimeout := viper.GetUint(commonParams.ClientTimeoutKey)
+	clientTimeout := uint(7 * 60)
 	customURL := fmt.Sprintf("%s/%s/download", r.path, reportID)
 	resp, err := SendHTTPRequest(http.MethodGet, customURL, http.NoBody, true, clientTimeout)
 	if err != nil {

--- a/internal/wrappers/results-pdf-http.go
+++ b/internal/wrappers/results-pdf-http.go
@@ -42,6 +42,8 @@ type PdfHTTPWrapper struct {
 	path string
 }
 
+const downloadTimeoutMinutes = 7
+
 func NewResultsPdfReportsHTTPWrapper(path string) ResultsPdfWrapper {
 	return &PdfHTTPWrapper{
 		path: path,
@@ -107,7 +109,7 @@ func (r *PdfHTTPWrapper) CheckPdfReportStatus(reportID string) (*PdfPollingRespo
 }
 
 func (r *PdfHTTPWrapper) DownloadPdfReport(reportID, targetFile string) error {
-	var clientTimeout = uint(7 * 60)
+	clientTimeout := uint(downloadTimeoutMinutes * 60)
 	customURL := fmt.Sprintf("%s/%s/download", r.path, reportID)
 	resp, err := SendHTTPRequest(http.MethodGet, customURL, http.NoBody, true, clientTimeout)
 	if err != nil {

--- a/internal/wrappers/results-pdf-http.go
+++ b/internal/wrappers/results-pdf-http.go
@@ -42,7 +42,7 @@ type PdfHTTPWrapper struct {
 	path string
 }
 
-const downloadTimeoutMinutes = 7
+const downloadTimeout = 420
 
 func NewResultsPdfReportsHTTPWrapper(path string) ResultsPdfWrapper {
 	return &PdfHTTPWrapper{
@@ -109,7 +109,7 @@ func (r *PdfHTTPWrapper) CheckPdfReportStatus(reportID string) (*PdfPollingRespo
 }
 
 func (r *PdfHTTPWrapper) DownloadPdfReport(reportID, targetFile string) error {
-	clientTimeout := uint(downloadTimeoutMinutes * 60)
+	clientTimeout := uint(downloadTimeout)
 	customURL := fmt.Sprintf("%s/%s/download", r.path, reportID)
 	resp, err := SendHTTPRequest(http.MethodGet, customURL, http.NoBody, true, clientTimeout)
 	if err != nil {

--- a/internal/wrappers/results-pdf-http.go
+++ b/internal/wrappers/results-pdf-http.go
@@ -49,7 +49,7 @@ func NewResultsPdfReportsHTTPWrapper(path string) ResultsPdfWrapper {
 }
 
 func (r *PdfHTTPWrapper) GeneratePdfReport(payload *PdfReportsPayload) (*PdfReportsResponse, *WebError, error) {
-	clientTimeout := viper.GetUint(commonParams.ClientTimeoutKey)
+	clientTimeout := 7
 	params, err := json.Marshal(payload)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "Failed to parse request body")

--- a/internal/wrappers/results-pdf-http.go
+++ b/internal/wrappers/results-pdf-http.go
@@ -107,7 +107,7 @@ func (r *PdfHTTPWrapper) CheckPdfReportStatus(reportID string) (*PdfPollingRespo
 }
 
 func (r *PdfHTTPWrapper) DownloadPdfReport(reportID, targetFile string) error {
-	clientTimeout := uint(7 * 60)
+	var clientTimeout = uint(7 * 60)
 	customURL := fmt.Sprintf("%s/%s/download", r.path, reportID)
 	resp, err := SendHTTPRequest(http.MethodGet, customURL, http.NoBody, true, clientTimeout)
 	if err != nil {

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -358,7 +358,7 @@ func TestScanCreateWithThresholdAndReportGenerate(t *testing.T) {
 	}
 
 	cmd := createASTIntegrationTestCommand(t)
-	err := executeWithTimeout(cmd, 2*time.Minute, args...)
+	err := executeWithTimeout(cmd, 5*time.Minute, args...)
 	assertError(t, err, "Threshold check finished with status Failed")
 
 	_, fileError := os.Stat(fmt.Sprintf("%s%s.%s", "/tmp/", "results", "json"))


### PR DESCRIPTION


### Description

> Increase the download timeout from 30 sec to 420 seconds (7 min)
because a big PDF takes time to download 

### References

> https://checkmarx.atlassian.net/browse/AST-42743

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used