### PR TITLE
Show response to console also in case of partial scan (AST-44163)

### DIFF
--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -312,6 +312,7 @@ func getScannerResponse(scanTypesFlagValue string, scanResponseModel *wrappers.S
 	if scanResponseModel.Status == wrappers.ScanCanceled ||
 		scanResponseModel.Status == wrappers.ScanRunning ||
 		scanResponseModel.Status == wrappers.ScanQueued ||
+		scanResponseModel.Status == wrappers.ScanPartial ||
 		scanResponseModel.Status == wrappers.ScanCompleted {
 		result := ScannerResponse{
 			ScanID: scanResponseModel.ID,

--- a/internal/commands/result_test.go
+++ b/internal/commands/result_test.go
@@ -117,7 +117,7 @@ func TestResultsExitCode_OnPartialScan_PrintOnlyFailedScannersInfoToConsole(t *t
 		Status: wrappers.ScanPartial,
 		StatusDetails: []wrappers.StatusInfo{
 			{Status: wrappers.ScanCompleted, Name: "sast"},
-			{Status: wrappers.ScanFailed, Name: "sca", Details: "error message from sca scanner", ErrorCode: 4343},
+			{Status: wrappers.ScanCanceled, Name: "sca", Details: "error message from sca scanner", ErrorCode: 4343},
 			{Status: wrappers.ScanCompleted, Name: "general"},
 		},
 	}
@@ -125,8 +125,8 @@ func TestResultsExitCode_OnPartialScan_PrintOnlyFailedScannersInfoToConsole(t *t
 	results := getScannerResponse("", &model)
 
 	assert.Equal(t, len(results), 1, "Scanner results should be empty")
-	assert.Equal(t, results[0].Name, "sca", "")
-	assert.Equal(t, results[0].ErrorCode, "4343", "")
+	assert.Equal(t, results[0].ScanID, "fake-scan-id-sca-fail-partial-id", "")
+	assert.Equal(t, results[0].Status, "Partial", "")
 }
 
 func TestResultsExitCode_OnCanceledScan_PrintOnlyScanIDAndStatusCanceledToConsole(t *testing.T) {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Show response in console also for a partial scan.

### References

> https://checkmarx.atlassian.net/browse/AST-44163

### Testing

> Modified an existing test.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used