### PR TITLE
CLI | Add check to symbolicLink value (AST-45529)

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1047,17 +1047,23 @@ func addDirFilesIgnoreFilter(zipWriter *zip.Writer, baseDir, parentDir string) e
 }
 
 func addDirFiles(zipWriter *zip.Writer, baseDir, parentDir string, filters, includeFilters []string) error {
-	files, err := os.ReadDir(parentDir)
+	fileEntries, err := os.ReadDir(parentDir)
 	if err != nil {
 		return err
 	}
-	for _, file := range files {
-		fileInfo, _ := file.Info()
+
+	for _, entry := range fileEntries {
+		fileInfo, err := entry.Info()
+		if err != nil {
+			return err
+		}
+
 		if util.IsDirOrSymLinkToDir(parentDir, fileInfo) {
 			err = handleDir(zipWriter, baseDir, parentDir, filters, includeFilters, fileInfo)
 		} else {
 			err = handleFile(zipWriter, baseDir, parentDir, filters, includeFilters, fileInfo)
 		}
+
 		if err != nil {
 			return err
 		}

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1047,15 +1047,16 @@ func addDirFilesIgnoreFilter(zipWriter *zip.Writer, baseDir, parentDir string) e
 }
 
 func addDirFiles(zipWriter *zip.Writer, baseDir, parentDir string, filters, includeFilters []string) error {
-	files, err := ioutil.ReadDir(parentDir)
+	files, err := os.ReadDir(parentDir)
 	if err != nil {
 		return err
 	}
 	for _, file := range files {
-		if file.IsDir() {
-			err = handleDir(zipWriter, baseDir, parentDir, filters, includeFilters, file)
+		fileInfo, _ := file.Info()
+		if util.IsDirOrSymLinkToDir(parentDir, fileInfo) {
+			err = handleDir(zipWriter, baseDir, parentDir, filters, includeFilters, fileInfo)
 		} else {
-			err = handleFile(zipWriter, baseDir, parentDir, filters, includeFilters, file)
+			err = handleFile(zipWriter, baseDir, parentDir, filters, includeFilters, fileInfo)
 		}
 		if err != nil {
 			return err

--- a/internal/commands/util/utils.go
+++ b/internal/commands/util/utils.go
@@ -2,7 +2,9 @@ package util
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"regexp"
 
 	"github.com/MakeNowJust/heredoc"
@@ -135,4 +137,29 @@ func ReadFileAsString(path string) (string, error) {
 	}
 
 	return string(content), nil
+}
+
+// IsDirOrSymLinkToDir Check if provided DirEntry is a directory or symbolic link to a directory
+func IsDirOrSymLinkToDir(parentDir string, fileInfo fs.FileInfo) bool {
+	if fileInfo.IsDir() {
+		return true
+	}
+
+	if fileInfo.Mode()&os.ModeSymlink != 0 {
+		symlinkPath := filepath.Join(parentDir, fileInfo.Name())
+		realPath, err := os.Readlink(symlinkPath)
+		if err != nil {
+			fmt.Println("Error reading symlink:", err)
+			return false
+		}
+
+		targetInfo, err := os.Stat(realPath)
+		if err != nil {
+			fmt.Println("Error getting target info:", err)
+			return false
+		}
+		return targetInfo.IsDir()
+	}
+
+	return false
 }

--- a/test/integration/data/project-with-directory-symlink/check/originalFolder.html/csharp-no-vul.cs
+++ b/test/integration/data/project-with-directory-symlink/check/originalFolder.html/csharp-no-vul.cs
@@ -1,0 +1,44 @@
+﻿namespace EvidenceResolver.Tests.Contract
+{
+    public static class MockProviderServiceExtenstion
+    {
+        public static IMockProviderService WithRequest(this IMockProviderService mockProviderService,
+            HttpVerb method, object path, object body = null, Dictionary<string, object> headers = null)
+        {
+            var providerServiceRequest = new ProviderServiceRequest
+            {
+                Method = method,
+                Path = path
+            };
+
+            providerServiceRequest.Headers = headers ?? new Dictionary<string, object>
+            {
+                {"Content-Type", "application/json"}
+            };
+
+            if (body != null) {
+                providerServiceRequest.Body = PactNet.Matchers.Match.Type(body);
+            }
+
+            return mockProviderService.With(providerServiceRequest);
+        }
+
+        public static void WillRespondParameters(this IMockProviderService mockProviderService,
+            int status, dynamic body = null, Dictionary<string, object> headers = null)
+        {
+            if (body == null) {
+                body = new { };
+            }
+
+            var expectedResponse = new ProviderServiceResponse
+            {
+                Status = status,
+                Headers = headers ?? new Dictionary<string, object>
+                    {{"Content-Type", "application/json; charset=utf-8"}},
+                Body = PactNet.Matchers.Match.Type(body)
+            };
+
+            mockProviderService.WillRespondWith(expectedResponse);
+        }
+    }
+}

--- a/test/integration/data/project-with-directory-symlink/originalFolder.html
+++ b/test/integration/data/project-with-directory-symlink/originalFolder.html
@@ -1,0 +1,1 @@
+/Users/benalvo/CxDev/workspace/Pheonix-workspace/ast-cli/test/integration/data/project-with-directory-symlink/check/originalFolder.html

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -298,6 +298,19 @@ func TestScanCreate_ExistingApplicationAndExistingProject_CreateScanSuccessfully
 	assert.NilError(t, err)
 }
 
+func TestScanCreate_FolderWithSymbolicLink_CreateScanSuccessfully(t *testing.T) {
+	args := []string{
+		"scan", "create",
+		flag(params.ProjectName), "my-project",
+		flag(params.SourcesFlag), "data/project-with-directory-symlink",
+		flag(params.ScanTypes), "iac-security",
+		flag(params.BranchFlag), "dummy_branch",
+	}
+
+	err, _ := executeCommand(t, args...)
+	assert.NilError(t, err)
+}
+
 func TestScanCreate_ExistingApplicationAndNotExistingProject_CreatingNewProjectAndCreateScanSuccessfully(t *testing.T) {
 	args := []string{
 		"scan", "create",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> The error occurred when we check if symbolicLink to a folder is a directory. I added another validation to check the value that it point at.

### References

> https://checkmarx.atlassian.net/browse/AST-45529

### Testing

> Added integration test

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used