### PR TITLE
revert  'not showing errors from SCA for threshold' (AST-43867)

### DIFF
--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -1032,7 +1032,7 @@ func CreateScanReport(
 		return err
 	}
 	if !scanPending {
-		results, err = ReadResults(resultsWrapper, scan, params, false)
+		results, err = ReadResults(resultsWrapper, scan, params)
 		if err != nil {
 			return err
 		}
@@ -1268,7 +1268,6 @@ func ReadResults(
 	resultsWrapper wrappers.ResultsWrapper,
 	scan *wrappers.ScanResponseModel,
 	params map[string]string,
-	isThresholdCheck bool,
 ) (results *wrappers.ScanResultsCollection, err error) {
 	var resultsModel *wrappers.ScanResultsCollection
 	var errorModel *wrappers.WebError
@@ -1291,7 +1290,7 @@ func ReadResults(
 			resultsModel = ComputeRedundantSastResults(resultsModel)
 		}
 		resultsModel, err = enrichScaResults(resultsWrapper, scan, params, resultsModel)
-		if err != nil && !isThresholdCheck {
+		if err != nil  {
 			return nil, err
 		}
 

--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -1290,7 +1290,7 @@ func ReadResults(
 			resultsModel = ComputeRedundantSastResults(resultsModel)
 		}
 		resultsModel, err = enrichScaResults(resultsWrapper, scan, params, resultsModel)
-		if err != nil  {
+		if err != nil {
 			return nil, err
 		}
 

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -2007,7 +2007,7 @@ func getSummaryThresholdMap(resultsWrapper wrappers.ResultsWrapper, scan *wrappe
 	map[string]int,
 	error,
 ) {
-	results, err := ReadResults(resultsWrapper, scan, params, true)
+	results, err := ReadResults(resultsWrapper, scan, params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

>In the past, we suppressed the exception and did not return an error if there was a failure. Now, we are reverting to the previous state and ensuring that an error is returned if there is a failure because the SAP error could not be reproduced. This decision was confirmed after checking with Michael Kubiaczyk, who used a SAP account for verification.


### References

>https://checkmarx.atlassian.net/browse/AST-43867
>https://checkmarx.atlassian.net/browse/AST-42820

