### PR TITLE
Add Flags for decreasing deployment size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build the project
-        run:  go build -o ./cx ./cmd
+        run:  go build -ldflags "-w -s" -o ./cx ./cmd
       - name: Build Docker image
         run: docker build -t ast-cli:${{ github.sha }} .
 

--- a/.goreleaser-dev.yml
+++ b/.goreleaser-dev.yml
@@ -29,8 +29,8 @@ builds:
       - goos: windows
         goarch: arm64
     ldflags:
-      - -s
       - -w
+      - -s
       - -X github.com/checkmarx/ast-cli/internal/params.Version={{.Version}}
     hooks:
       post:
@@ -54,8 +54,8 @@ builds:
       - arm
       - arm64
     ldflags:
-      - -s
       - -w
+      - -s
       - -X github.com/checkmarx/ast-cli/internal/params.Version={{.Version}}
 
 archives:

--- a/.goreleaser-dev.yml
+++ b/.goreleaser-dev.yml
@@ -4,7 +4,7 @@ release:
   prerelease: true
   name_template: 'Checkmarx One CLI {{.Version}}'
 
-# .goreleaser-dev.yml
+# Enable UPX compression
 upx:
   args:
     - --best
@@ -15,13 +15,12 @@ builds:
       - CGO_ENABLED=0
     binary: cx
     id: cx
+    # Trim down the target platforms
     goos:
       - linux
       - windows
     goarch:
       - amd64
-      - arm
-      - arm64
     ignore:
       - goos: darwin
         goarch: 386
@@ -33,6 +32,7 @@ builds:
         goarch: arm
       - goos: windows
         goarch: arm64
+    # Review your build flags
     ldflags:
       - -w
       - -s
@@ -52,15 +52,13 @@ builds:
       - CGO_ENABLED=0
     binary: cx
     id: cx-mac-universal
+    # Trim down the target platforms
     goos:
       - darwin
     goarch:
       - amd64
-      - arm
-      - arm64
+    # Review your build flags
     ldflags:
-      - -w
-      - -s
       - -X github.com/checkmarx/ast-cli/internal/params.Version={{.Version}}
 
 archives:

--- a/.goreleaser-dev.yml
+++ b/.goreleaser-dev.yml
@@ -4,6 +4,11 @@ release:
   prerelease: true
   name_template: 'Checkmarx One CLI {{.Version}}'
 
+# .goreleaser-dev.yml
+upx:
+  args:
+    - --best
+
 builds:
   - main: ./cmd/main.go
     env:

--- a/.goreleaser-dev.yml
+++ b/.goreleaser-dev.yml
@@ -4,11 +4,6 @@ release:
   prerelease: true
   name_template: 'Checkmarx One CLI {{.Version}}'
 
-# Enable UPX compression
-upx:
-  args:
-    - --best
-
 builds:
   - main: ./cmd/main.go
     env:
@@ -57,6 +52,8 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm
+      - arm64
     # Review your build flags
     ldflags:
       - -X github.com/checkmarx/ast-cli/internal/params.Version={{.Version}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,8 +28,8 @@ builds:
       - goos: windows
         goarch: arm64
     ldflags:
-      - -s
       - -w
+      - -s
       - -X github.com/checkmarx/ast-cli/internal/params.Version={{.Version}}
     hooks:
       post:
@@ -53,8 +53,8 @@ builds:
       - arm
       - arm64
     ldflags:
-      - -s
       - -w
+      - -s
       - -X github.com/checkmarx/ast-cli/internal/params.Version={{.Version}}
 
 dockers:

--- a/README.md
+++ b/README.md
@@ -73,24 +73,27 @@ To be able to build the code you should have:
 ``` powershell
 setx GOOS=windows 
 setx GOARCH=amd64
-go build -o ./bin/cx.exe ./cmd
+go build -ldflags "-w -s" -o ./bin/cx.exe ./cmd
 ```
 
 #### Linux
-
 ``` bash
 export GOARCH=amd64
 export GOOS=linux
-go build -o ./bin/cx ./cmd
+go build -ldflags "-w -s" -o ./bin/cx ./cmd
 ```
 
 #### Macintosh
-
 ``` bash
 export GOOS=darwin 
 export GOARCH=amd64
-go build -o ./bin/cx-mac ./cmd
+go build -ldflags "-w -s" -o ./bin/cx-mac ./cmd
 ```
+
+## Build Flags
+Use the -ldflags "-w -s" flags to reduce the binary size (Deployment).
+For local development and debugging: Do not use the -ldflags "-w -s" flags
+
 ### Makefile
 For ease of use, a Makefile is provided to build the project for all platforms.
 


### PR DESCRIPTION
### Description

> The CLI size with container revolver increased to over 100MB, this PR uses go build flags for removing tracing metadata when deploying
### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Integration/Unit

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used