### PR TITLE
CLI | Add check to symbolicLink value with relative path (AST-45529)

### DIFF
--- a/internal/commands/util/utils.go
+++ b/internal/commands/util/utils.go
@@ -147,7 +147,6 @@ func ReadFileAsString(path string) (string, error) {
 
 // IsDirOrSymLinkToDir Check if provided DirEntry is a directory or symbolic link to a directory
 func IsDirOrSymLinkToDir(parentDir string, fileInfo fs.FileInfo) bool {
-	// Check if the FileInfo represents a directory
 	if fileInfo.IsDir() {
 		return true
 	}

--- a/internal/commands/util/utils.go
+++ b/internal/commands/util/utils.go
@@ -147,6 +147,7 @@ func ReadFileAsString(path string) (string, error) {
 
 // IsDirOrSymLinkToDir Check if provided DirEntry is a directory or symbolic link to a directory
 func IsDirOrSymLinkToDir(parentDir string, fileInfo fs.FileInfo) bool {
+	// Check if the FileInfo represents a directory
 	if fileInfo.IsDir() {
 		return true
 	}
@@ -157,6 +158,10 @@ func IsDirOrSymLinkToDir(parentDir string, fileInfo fs.FileInfo) bool {
 		if err != nil {
 			fmt.Println("Error reading symlink:", err)
 			return false
+		}
+
+		if !filepath.IsAbs(realPath) {
+			realPath = filepath.Join(parentDir, realPath)
 		}
 
 		targetInfo, err := os.Stat(realPath)

--- a/internal/commands/util/utils.go
+++ b/internal/commands/util/utils.go
@@ -151,7 +151,6 @@ func IsDirOrSymLinkToDir(parentDir string, fileInfo fs.FileInfo) bool {
 	if fileInfo.IsDir() {
 		return true
 	}
-
 	if fileInfo.Mode()&os.ModeSymlink != 0 {
 		symlinkPath := filepath.Join(parentDir, fileInfo.Name())
 		realPath, err := os.Readlink(symlinkPath)
@@ -171,7 +170,6 @@ func IsDirOrSymLinkToDir(parentDir string, fileInfo fs.FileInfo) bool {
 		}
 		return targetInfo.IsDir()
 	}
-
 	return false
 }
 

--- a/internal/services/vorpal_test.go
+++ b/internal/services/vorpal_test.go
@@ -85,6 +85,8 @@ func TestCreateVorpalScanRequest_EngineRunningAndSpecialAgentAndNoLicense_Fail(t
 		FeatureFlagsWrapper: &mock.FeatureFlagsMockWrapper{},
 		VorpalWrapper:       grpcs.NewVorpalGrpcWrapper(port),
 	}
+	err = manageVorpalInstallation(vorpalParams, wrapperParams)
+	assert.Nil(t, err)
 
 	err = ensureVorpalServiceRunning(wrapperParams, vorpalParams)
 	assert.Nil(t, err)
@@ -114,6 +116,8 @@ func TestCreateVorpalScanRequest_EngineRunningAndDefaultAgentAndNoLicense_Succes
 		FeatureFlagsWrapper: &mock.FeatureFlagsMockWrapper{},
 		VorpalWrapper:       grpcs.NewVorpalGrpcWrapper(port),
 	}
+	err = manageVorpalInstallation(vorpalParams, wrapperParams)
+	assert.Nil(t, err)
 
 	err = ensureVorpalServiceRunning(wrapperParams, vorpalParams)
 	assert.Nil(t, err)

--- a/internal/services/vorpal_test.go
+++ b/internal/services/vorpal_test.go
@@ -112,12 +112,14 @@ func TestCreateVorpalScanRequest_EngineRunningAndDefaultAgentAndNoLicense_Succes
 	}
 
 	wrapperParams := VorpalWrappersParam{
-		JwtWrapper:          &mock.JWTMockWrapper{AIEnabled: mock.AIProtectionDisabled},
+		JwtWrapper:          &mock.JWTMockWrapper{},
 		FeatureFlagsWrapper: &mock.FeatureFlagsMockWrapper{},
 		VorpalWrapper:       grpcs.NewVorpalGrpcWrapper(port),
 	}
 	err = manageVorpalInstallation(vorpalParams, wrapperParams)
 	assert.Nil(t, err)
+
+	wrapperParams.JwtWrapper = &mock.JWTMockWrapper{AIEnabled: mock.AIProtectionDisabled}
 
 	err = ensureVorpalServiceRunning(wrapperParams, vorpalParams)
 	assert.Nil(t, err)

--- a/test/integration/data/symlink-relative-path-folder/datas.html
+++ b/test/integration/data/symlink-relative-path-folder/datas.html
@@ -1,0 +1,1 @@
+test/datas.html

--- a/test/integration/data/symlink-relative-path-folder/test/datas.html/cx_result.json
+++ b/test/integration/data/symlink-relative-path-folder/test/datas.html/cx_result.json
@@ -1,0 +1,299 @@
+{
+    "results": [
+        {
+            "type": "sast",
+            "label": "sast",
+            "id": "13588362",
+            "similarityId": "1959005240",
+            "status": "NEW",
+            "state": "TO_VERIFY",
+            "severity": "HIGH",
+            "created": "2023-11-29T16:00:29Z",
+            "firstFoundAt": "2023-11-24T10:27:23Z",
+            "foundAt": "2023-11-29T16:00:29Z",
+            "firstScanId": "12c2e25b-d25a-4321-9ce2-79a4df314d38",
+            "description": "The method Lambda embeds untrusted data in generated output with html, at line 18 of /src/main/resources/lessons/challenges/js/challenge8.js. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\n\n",
+            "descriptionHTML": "\u003cp\u003eThe method Lambda embeds untrusted data in generated output with html, at line 18 of /src/main/resources/lessons/challenges/js/challenge8.js. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\u003c/p\u003e\n",
+            "data": {
+                "queryId": 1779421333800271656,
+                "queryName": "Client_DOM_Stored_XSS",
+                "group": "JavaScript_High_Risk",
+                "resultHash": "vu/B9/LA3CAJTW+YXs3WsnzYc14=",
+                "languageName": "JavaScript",
+                "nodes": [
+                    {
+                        "id": "I09eTl48jtJ+UqDgeyBVAQ/oiYI=",
+                        "line": 7,
+                        "name": "votes",
+                        "column": 43,
+                        "length": 5,
+                        "method": "Lambda",
+                        "nodeID": 167070,
+                        "domType": "ParamDecl",
+                        "fileName": "/challenge8-js.testdata",
+                        "fullName": "CxJSNS_953c03de.loadVotes.Lambda.votes",
+                        "typeName": "object",
+                        "methodLine": 7,
+                        "definitions": "1"
+                    },
+                    {
+                        "id": "RJLk6yhAIFf46AYFkZGpG5BITrE=",
+                        "line": 18,
+                        "name": "votes",
+                        "column": 42,
+                        "length": 5,
+                        "method": "Lambda",
+                        "nodeID": 167232,
+                        "domType": "UnknownReference",
+                        "fileName": "/challenge8-js.testdata",
+                        "fullName": "CxJSNS_953c03de.loadVotes.Lambda.votes",
+                        "typeName": "object",
+                        "methodLine": 7,
+                        "definitions": "1"
+                    },
+                    {
+                        "id": "wu4zwsJQtEpEwABrFtX8o1/8u8E=",
+                        "line": 18,
+                        "name": "html",
+                        "column": 37,
+                        "length": 4,
+                        "method": "Lambda",
+                        "nodeID": 167226,
+                        "domType": "MethodInvokeExpr",
+                        "fileName": "/challenge8-js.testdata",
+                        "fullName": "html",
+                        "typeName": "html",
+                        "methodLine": 7,
+                        "definitions": "0"
+                    }
+                ]
+            },
+            "comments": {},
+            "vulnerabilityDetails": {
+                "cweId": 79,
+                "cvss": {},
+                "compliances": [
+                    "FISMA 2014",
+                    "MOIS(KISA) Secure Coding 2021",
+                    "OWASP Top 10 2013",
+                    "OWASP Top 10 2021",
+                    "PCI DSS v3.2.1",
+                    "NIST SP 800-53",
+                    "OWASP ASVS",
+                    "CWE top 25",
+                    "ASD STIG 4.10",
+                    "SANS top 25",
+                    "OWASP Top 10 2017"
+                ]
+            }
+        },
+        {
+            "type": "sast",
+            "label": "sast",
+            "id": "13588363",
+            "similarityId": "15011039",
+            "status": "NEW",
+            "state": "TO_VERIFY",
+            "severity": "HIGH",
+            "created": "2023-11-29T16:00:29Z",
+            "firstFoundAt": "2023-11-24T10:27:23Z",
+            "foundAt": "2023-11-29T16:00:29Z",
+            "firstScanId": "12c2e25b-d25a-4321-9ce2-79a4df314d38",
+            "description": "The method Lambda embeds untrusted data in generated output with html, at line 57 of /src/main/resources/webgoat/static/js/goatApp/support/GoatUtils.js. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\n\n",
+            "descriptionHTML": "\u003cp\u003eThe method Lambda embeds untrusted data in generated output with html, at line 57 of /src/main/resources/webgoat/static/js/goatApp/support/GoatUtils.js. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\u003c/p\u003e\n",
+            "data": {
+                "queryId": 1779421333800271656,
+                "queryName": "Client_DOM_Stored_XSS",
+                "group": "JavaScript_High_Risk",
+                "resultHash": "jFgXDclJK/RDlpwY3fbow/7lVv8=",
+                "languageName": "JavaScript",
+                "nodes": [
+                    {
+                        "id": "voHHLkc4qjb3UpedvmZQayOk03I=",
+                        "line": 56,
+                        "name": "reply",
+                        "column": 69,
+                        "length": 5,
+                        "method": "Lambda",
+                        "nodeID": 183497,
+                        "domType": "ParamDecl",
+                        "fileName": "/GoatUtils-js.testdata",
+                        "fullName": "CxJSNS_b114a3b8.CxAssociativeArray_75dc0652.Cxc09a0906.Lambda.reply",
+                        "typeName": "object",
+                        "methodLine": 56,
+                        "definitions": "1"
+                    },
+                    {
+                        "id": "IbtfjyTk3jy5XU57DiAGTLLtJKY=",
+                        "line": 57,
+                        "name": "reply",
+                        "column": 51,
+                        "length": 5,
+                        "method": "Lambda",
+                        "nodeID": 183516,
+                        "domType": "UnknownReference",
+                        "fileName": "/GoatUtils-js.testdata",
+                        "fullName": "CxJSNS_b114a3b8.CxAssociativeArray_75dc0652.Cxc09a0906.Lambda.reply",
+                        "typeName": "object",
+                        "methodLine": 56,
+                        "definitions": "1"
+                    },
+                    {
+                        "id": "ZMHi6gwUdqfEtqo08wbDlnaGuKA=",
+                        "line": 57,
+                        "name": "html",
+                        "column": 46,
+                        "length": 4,
+                        "method": "Lambda",
+                        "nodeID": 183512,
+                        "domType": "MethodInvokeExpr",
+                        "fileName": "/GoatUtils-js.testdata",
+                        "fullName": "CxJSNS_b114a3b8.CxAssociativeArray_75dc0652.Cxc09a0906.Lambda.html",
+                        "typeName": "html",
+                        "methodLine": 56,
+                        "definitions": "0"
+                    }
+                ]
+            },
+            "comments": {},
+            "vulnerabilityDetails": {
+                "cweId": 79,
+                "cvss": {},
+                "compliances": [
+                    "FISMA 2014",
+                    "MOIS(KISA) Secure Coding 2021",
+                    "OWASP Top 10 2013",
+                    "OWASP Top 10 2021",
+                    "PCI DSS v3.2.1",
+                    "NIST SP 800-53",
+                    "OWASP ASVS",
+                    "CWE top 25",
+                    "ASD STIG 4.10",
+                    "SANS top 25",
+                    "OWASP Top 10 2017"
+                ]
+            }
+        },
+        {
+            "type": "kics",
+            "label": "IaC Security",
+            "id": "16350365",
+            "similarityId": "531bf8e9771fc9a38b866afcdc86e10dd80487262d98baf44f82522516f4db9e",
+            "status": "NEW",
+            "state": "TO_VERIFY",
+            "severity": "HIGH",
+            "created": "2023-11-29T15:54:59Z",
+            "firstFoundAt": "2023-11-29T15:54:59Z",
+            "foundAt": "2023-11-29T15:54:59Z",
+            "firstScanId": "dc2b7f5c-625d-4236-891d-90869454aaf7",
+            "description": "A user should be specified in the dockerfile, otherwise the image will run as root",
+            "descriptionHTML": "\u003cp\u003eA user should be specified in the dockerfile, otherwise the image will run as root\u003c/p\u003e\n",
+            "data": {
+                "queryId": "fd54f200-402c-4333-a5a4-36ef6709af2f [Taken from query_id]",
+                "queryName": "Missing User Instruction",
+                "group": "Build Process [Taken from category]",
+                "line": 1,
+                "platform": "Dockerfile",
+                "issueType": "MissingAttribute",
+                "expectedValue": "The 'Dockerfile' should contain the 'USER' instruction",
+                "value": "The 'Dockerfile' does not contain any 'USER' instruction",
+                "filename": "/Dockerfile_desktop"
+            },
+            "comments": {},
+            "vulnerabilityDetails": {
+                "cvss": {}
+            }
+        },
+        {
+            "type": "sca",
+            "scaType": "Vulnerability",
+            "label": "sca",
+            "id": "CVE-2013-7285",
+            "similarityId": "CVE-2013-7285",
+            "status": "NEW",
+            "state": "TO_VERIFY",
+            "severity": "HIGH",
+            "created": "2023-11-29T15:58:19Z",
+            "firstFoundAt": "2023-11-24T10:25:10Z",
+            "foundAt": "2023-11-29T15:58:19Z",
+            "firstScanId": "12c2e25b-d25a-4321-9ce2-79a4df314d38",
+            "description": "Xstream API versions up to 1.4.6, if the security framework has not been initialized, may allow a remote attacker to run arbitrary shell commands by manipulating the processed input stream when unmarshaling XML or any supported format. e.g. JSON.",
+            "descriptionHTML": "\u003cp\u003eXstream API versions up to 1.4.6, if the security framework has not been initialized, may allow a remote attacker to run arbitrary shell commands by manipulating the processed input stream when unmarshaling XML or any supported format. e.g. JSON.\u003c/p\u003e\n",
+            "data": {
+                "packageData": [
+                    {
+                        "comment": "https://github.com/advisories/GHSA-f554-x222-wgf7",
+                        "type": "Advisory",
+                        "url": "https://github.com/advisories/GHSA-f554-x222-wgf7"
+                    },
+                    {
+                        "comment": "https://x-stream.github.io/CVE-2013-7285.html",
+                        "type": "Advisory",
+                        "url": "https://x-stream.github.io/CVE-2013-7285.html"
+                    },
+                    {
+                        "comment": "http://blog.diniscruz.com/2013/12/xstream-remote-code-execution-exploit.html",
+                        "type": "Disclosure",
+                        "url": "http://blog.diniscruz.com/2013/12/xstream-remote-code-execution-exploit.html"
+                    },
+                    {
+                        "comment": "https://www.mail-archive.com/user@xstream.codehaus.org/msg00604.html",
+                        "type": "Mail Thread",
+                        "url": "https://www.mail-archive.com/user@xstream.codehaus.org/msg00604.html"
+                    },
+                    {
+                        "comment": "https://www.mail-archive.com/user@xstream.codehaus.org/msg00607.html",
+                        "type": "Mail Thread",
+                        "url": "https://www.mail-archive.com/user@xstream.codehaus.org/msg00607.html"
+                    },
+                    {
+                        "comment": "https://github.com/x-stream/xstream/commit/94666ae6dfe839410c73bdfeeb211374f04a2059",
+                        "type": "Commit",
+                        "url": "https://github.com/x-stream/xstream/commit/94666ae6dfe839410c73bdfeeb211374f04a2059"
+                    }
+                ],
+                "packageIdentifier": "Maven-com.thoughtworks.xstream:xstream-1.4.5",
+                "scaPackageData": {
+                    "id": "Maven-com.thoughtworks.xstream:xstream-1.4.5",
+                    "fixLink": "https://devhub.checkmarx.com/cve-details/CWE-78",
+                    "locations": [
+                        "pom.xml"
+                    ],
+                    "dependencyPaths": [
+                        [
+                            {
+                                "id": "Maven-com.thoughtworks.xstream:xstream-1.4.5",
+                                "name": "com.thoughtworks.xstream:xstream",
+                                "version": "1.4.5",
+                                "isResolved": true,
+                                "locations": [
+                                    "pom.xml"
+                                ]
+                            }
+                        ]
+                    ],
+                    "outdated": true,
+                    "supportsQuickFix": false,
+                    "isDirectDependency": true,
+                    "typeOfDependency": "Direct Dependency"
+                },
+                "recommendedVersion": "1.4.20"
+            },
+            "comments": {},
+            "vulnerabilityDetails": {
+                "cweId": "CWE-78",
+                "cvssScore": 9.8,
+                "cveName": "CWE-78",
+                "cvss": {
+                    "version": 3,
+                    "attackVector": "NETWORK",
+                    "availability": "HIGH",
+                    "confidentiality": "HIGH",
+                    "attackComplexity": "LOW"
+                }
+            }
+        }
+    ],
+    "totalCount": 4,
+    "scanID": "dc2b7f5c-625d-4236-891d-90869454aaf7"
+}

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -300,7 +300,7 @@ func TestScanCreate_ExistingApplicationAndExistingProject_CreateScanSuccessfully
 	assert.NilError(t, err)
 }
 
-func TestScanCreate_FolderWithSymbolicLink_CreateScanSuccessfully(t *testing.T) {
+func TestScanCreate_FolderWithSymbolicLinkWithAbsolutePath_CreateScanSuccessfully(t *testing.T) {
 	args := []string{
 		"scan", "create",
 		flag(params.ProjectName), "my-project",
@@ -308,7 +308,18 @@ func TestScanCreate_FolderWithSymbolicLink_CreateScanSuccessfully(t *testing.T) 
 		flag(params.ScanTypes), "iac-security",
 		flag(params.BranchFlag), "dummy_branch",
 	}
+	err, _ := executeCommand(t, args...)
+	assert.NilError(t, err)
+}
 
+func TestScanCreate_FolderWithSymbolicLinkWithRelativePath_CreateScanSuccessfully(t *testing.T) {
+	args := []string{
+		"scan", "create",
+		flag(params.ProjectName), "my-project",
+		flag(params.SourcesFlag), "data/symlink-relative-path-folder",
+		flag(params.ScanTypes), "iac-security",
+		flag(params.BranchFlag), "dummy_branch",
+	}
 	err, _ := executeCommand(t, args...)
 	assert.NilError(t, err)
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> An error occurred while checking the target value of a symbolic link that points to a directory or a file. When a symbolic link points to a file/folder and shares a common path, the ReadLink function returns a relative path instead of the full path, causing a flow error.

### References

> https://checkmarx.atlassian.net/browse/AST-45529

### Testing

> Added integration test

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used