### PR TITLE
Remove spaces from branch name to prevent duplication (AST-63539)

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1747,7 +1747,7 @@ func setupScanHandler(cmd *cobra.Command, uploadsWrapper wrappers.UploadsWrapper
 ) {
 	zipFilePath := ""
 	scanHandler := wrappers.ScanHandler{}
-	scanHandler.Branch = viper.GetString(commonParams.BranchKey)
+	scanHandler.Branch = strings.TrimSpace(viper.GetString(commonParams.BranchKey))
 
 	uploadType := getUploadType(cmd)
 
@@ -2634,7 +2634,7 @@ func deprecatedFlagValue(cmd *cobra.Command, deprecatedFlagKey, inUseFlagKey str
 }
 
 func validateCreateScanFlags(cmd *cobra.Command) error {
-	branch := viper.GetString(commonParams.BranchKey)
+	branch := strings.TrimSpace(viper.GetString(commonParams.BranchKey))
 	if branch == "" {
 		return errors.Errorf("%s: Please provide a branch", failedCreating)
 	}

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -1844,7 +1844,7 @@ func validateCheckmarxDomains(t *testing.T, usedDomainsInTests []string) {
 }
 
 func TestCreateScan_TwoScansWithSameBranchNameWithWhiteSpace_Success(t *testing.T) {
-	projectName := "uniqueName" + uuid.New().String()
+	projectName := generateRandomProjectNameForScan()
 	args := []string{
 		scanCommand, "create",
 		flag(params.ProjectName), projectName,

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/checkmarx/ast-cli/internal/services"
 	"github.com/checkmarx/ast-cli/internal/wrappers"
 	"github.com/checkmarx/ast-cli/internal/wrappers/configuration"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	asserts "github.com/stretchr/testify/assert"


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.
 
### Description
 
> The bug was when you create a scan with the same name in branch as in a previous scan but with spaces, it doesn't differentiate and creates with the same name in branch
 
The solution - delete spaces and thus identify that it is the same branch and therefore no more will be opened

### References
 
> https://checkmarx.atlassian.net/browse/AST-63539
 
### Testing
 
> Creating 2 scans, one with a normal branch name and the other with spaces, finally check if the names are the same (deleting spaces)
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
 
### Checklist
 
- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used