### PR TITLE
Display the description result incorrectly if the vulnerability contains quotation (AST-40454)

### DIFF
--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"log"
 	"net/url"
 	"os"
@@ -1559,7 +1560,21 @@ func exportSonarResults(targetFile string, results *wrappers.ScanResultsCollecti
 	_ = f.Close()
 	return nil
 }
+
+// Function to decode HTML entities in the ScanResultsCollection
+func decodeHTMLEntitiesInResults(results *wrappers.ScanResultsCollection) {
+	for _, result := range results.Results {
+		result.Description = html.UnescapeString(result.Description)
+		result.DescriptionHTML = html.UnescapeString(result.DescriptionHTML)
+		for _, node := range result.ScanResultData.Nodes {
+			node.FullName = html.UnescapeString(node.FullName)
+			node.Name = html.UnescapeString(node.Name)
+		}
+	}
+}
+
 func exportJSONResults(targetFile string, results *wrappers.ScanResultsCollection) error {
+	decodeHTMLEntitiesInResults(results)
 	var err error
 	var resultsJSON []byte
 	log.Println("Creating JSON Report: ", targetFile)

--- a/internal/commands/result_test.go
+++ b/internal/commands/result_test.go
@@ -237,6 +237,42 @@ func TestRunGetResultsByScanIdJsonFormat(t *testing.T) {
 	// Remove generated json file
 	removeFileBySuffix(t, printer.FormatJSON)
 }
+func createTestScanResultsCollection() *wrappers.ScanResultsCollection {
+	return &wrappers.ScanResultsCollection{
+		Results: []*wrappers.ScanResult{
+			{
+				Description:     "Vulnerability in SomeComponent",
+				DescriptionHTML: "Description with quotes",
+				ScanResultData: wrappers.ScanResultData{
+					Nodes: []*wrappers.ScanResultNode{
+						{
+							FullName: "SomeClass&lt;T&gt;",
+							Name:     "Name with &quot;quotes&quot;",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestDecodeHTMLEntitiesInResults(t *testing.T) {
+	// Setup: Creating test data with HTML entities
+	results := createTestScanResultsCollection()
+
+	decodeHTMLEntitiesInResults(results)
+
+	expectedFullName := `SomeClass<T>`
+	expectedName := `Name with "quotes"`
+
+	if results.Results[0].ScanResultData.Nodes[0].FullName != expectedFullName {
+		t.Errorf("expected FullName to be %q, got %q", expectedFullName, results.Results[0].ScanResultData.Nodes[0].FullName)
+	}
+
+	if results.Results[0].ScanResultData.Nodes[0].Name != expectedName {
+		t.Errorf("expected Name to be %q, got %q", expectedName, results.Results[0].ScanResultData.Nodes[0].Name)
+	}
+}
 
 func TestRunGetResultsByScanIdJsonFormatWithContainers(t *testing.T) {
 	clearFlags()

--- a/internal/commands/result_test.go
+++ b/internal/commands/result_test.go
@@ -237,24 +237,6 @@ func TestRunGetResultsByScanIdJsonFormat(t *testing.T) {
 	// Remove generated json file
 	removeFileBySuffix(t, printer.FormatJSON)
 }
-func createTestScanResultsCollection() *wrappers.ScanResultsCollection {
-	return &wrappers.ScanResultsCollection{
-		Results: []*wrappers.ScanResult{
-			{
-				Description:     "Vulnerability in SomeComponent",
-				DescriptionHTML: "Description with quotes",
-				ScanResultData: wrappers.ScanResultData{
-					Nodes: []*wrappers.ScanResultNode{
-						{
-							FullName: "SomeClass&lt;T&gt;",
-							Name:     "Name with &quot;quotes&quot;",
-						},
-					},
-				},
-			},
-		},
-	}
-}
 
 func TestDecodeHTMLEntitiesInResults(t *testing.T) {
 	// Setup: Creating test data with HTML entities
@@ -344,6 +326,25 @@ func TestRunGetResultsByScanIdSummaryMarkdownFormat(t *testing.T) {
 	execCmdNilAssertion(t, "results", "show", "--scan-id", "MOCK", "--report-format", "markdown")
 	// Remove generated md file
 	removeFileBySuffix(t, "md")
+}
+
+func createTestScanResultsCollection() *wrappers.ScanResultsCollection {
+	return &wrappers.ScanResultsCollection{
+		Results: []*wrappers.ScanResult{
+			{
+				Description:     "Vulnerability in SomeComponent",
+				DescriptionHTML: "Description with quotes",
+				ScanResultData: wrappers.ScanResultData{
+					Nodes: []*wrappers.ScanResultNode{
+						{
+							FullName: "SomeClass&lt;T&gt;",
+							Name:     "Name with &quot;quotes&quot;",
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func removeFileBySuffix(t *testing.T, suffix string) {


### PR DESCRIPTION


### Description

> Eclipse & visual studio extension, display description incorrectly if vulnerability has ""

### References

> https://checkmarx.atlassian.net/browse/AST-40454

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used