### PR TITLE
 Support SCS Vulnerabilities in json report when Agent is VSCode/AST-CLI (AST-63907)

### DIFF
--- a/internal/commands/result_test.go
+++ b/internal/commands/result_test.go
@@ -5,6 +5,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -130,6 +131,192 @@ func TestResultsExitCode_OnPartialScan_PrintOnlyFailedScannersInfoToConsole(t *t
 	assert.Equal(t, len(results), 1, "Scanner results should be empty")
 	assert.Equal(t, results[0].ScanID, "fake-scan-id-sca-fail-partial-id", "")
 	assert.Equal(t, results[0].Status, "Partial", "")
+}
+
+func TestRunScsResultsShow_ASTCLI_AgentShouldShowAllResults(t *testing.T) {
+	executeCommand := func(agent string) *wrappers.ScanResultsCollection {
+		clearFlags()
+		mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.SCSEngineCLIEnabled, Status: true}
+
+		_, err := executeRedirectedOsStdoutTestCommand(createASTTestCommand(),
+			"results", "show", "--scan-id", "SCS", "--report-format", "json", "--agent", agent)
+		assert.NilError(t, err)
+
+		file, err := os.Open(fileName + ".json")
+		if err != nil {
+			t.Fatalf("failed to open file: %v", err)
+		}
+		defer file.Close()
+
+		fileContents, err := io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+
+		var results wrappers.ScanResultsCollection
+		err = json.Unmarshal(fileContents, &results)
+		assert.NilError(t, err)
+		return &results
+	}
+
+	results := executeCommand(params.DefaultAgent)
+	scsSecretDetectionFound := false
+	scsScorecardFound := false
+	for _, result := range results.Results {
+		if result.Type == params.SCSSecretDetectionType {
+			scsSecretDetectionFound = true
+		}
+		if result.Type == params.SCSScorecardType {
+			scsScorecardFound = true
+		}
+		if scsSecretDetectionFound && scsScorecardFound {
+			break
+		}
+	}
+	assert.Assert(t, scsSecretDetectionFound && scsScorecardFound, "SCS results should be included for AST-CLI agent")
+	assert.Assert(t, results.TotalCount == 2, "SCS Scorecard results should be excluded for VS Code agent")
+
+	defer os.Remove(fileName + ".json")
+}
+
+func TestRunScsResultsShow_VSCode_AgentShouldNotShowScorecardResults(t *testing.T) {
+	executeCommand := func(agent string) *wrappers.ScanResultsCollection {
+		clearFlags()
+		mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.SCSEngineCLIEnabled, Status: true}
+
+		_, err := executeRedirectedOsStdoutTestCommand(createASTTestCommand(),
+			"results", "show", "--scan-id", "SCS", "--report-format", "json", "--agent", agent)
+		assert.NilError(t, err)
+
+		file, err := os.Open(fileName + ".json")
+		if err != nil {
+			t.Fatalf("failed to open file: %v", err)
+		}
+		defer file.Close()
+
+		fileContents, err := io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+
+		var results wrappers.ScanResultsCollection
+		err = json.Unmarshal(fileContents, &results)
+		assert.NilError(t, err)
+		return &results
+	}
+
+	results := executeCommand(params.VSCodeAgent)
+	for _, result := range results.Results {
+		assert.Assert(t, result.Type != params.SCSScorecardType, "SCS Scorecard results should be excluded for VS Code agent")
+	}
+	assert.Assert(t, results.TotalCount == 1, "SCS Scorecard results should be excluded for VS Code agent")
+
+	defer os.Remove(fileName + ".json")
+}
+
+func TestRunScsResultsShow_Other_AgentsShouldNotShowScsResults(t *testing.T) {
+	executeCommand := func(agent string) *wrappers.ScanResultsCollection {
+		clearFlags()
+		mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.SCSEngineCLIEnabled, Status: true}
+
+		_, err := executeRedirectedOsStdoutTestCommand(createASTTestCommand(),
+			"results", "show", "--scan-id", "SCS", "--report-format", "json", "--agent", agent)
+		assert.NilError(t, err)
+
+		file, err := os.Open(fileName + ".json")
+		if err != nil {
+			t.Fatalf("failed to open file: %v", err)
+		}
+		defer file.Close()
+
+		fileContents, err := io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+
+		var results wrappers.ScanResultsCollection
+		err = json.Unmarshal(fileContents, &results)
+		assert.NilError(t, err)
+		return &results
+	}
+
+	results := executeCommand("Jetbrains")
+	for _, result := range results.Results {
+		assert.Assert(t, result.Type != params.SCSScorecardType && result.Type != params.SCSSecretDetectionType, "SCS results should be excluded for other agents")
+	}
+	assert.Assert(t, results.TotalCount == 0, "SCS Scorecard results should be excluded")
+
+	defer os.Remove(fileName + ".json")
+}
+
+func TestRunWithoutScsResults_Other_AgentsShouldNotShowScsResults(t *testing.T) {
+	executeCommand := func(agent string) *wrappers.ScanResultsCollection {
+		clearFlags()
+		mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.SCSEngineCLIEnabled, Status: true}
+		mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.ContainerEngineCLIEnabled, Status: true}
+
+		_, err := executeRedirectedOsStdoutTestCommand(createASTTestCommand(),
+			"results", "show", "--scan-id", "MOCK", "--report-format", "json", "--agent", agent)
+		assert.NilError(t, err)
+
+		file, err := os.Open(fileName + ".json")
+		if err != nil {
+			t.Fatalf("failed to open file: %v", err)
+		}
+		defer file.Close()
+
+		fileContents, err := io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+
+		var results wrappers.ScanResultsCollection
+		err = json.Unmarshal(fileContents, &results)
+		assert.NilError(t, err)
+		return &results
+	}
+
+	results := executeCommand("Jetbrains")
+	for _, result := range results.Results {
+		assert.Assert(t, result.Type != params.SCSScorecardType && result.Type != params.SCSSecretDetectionType, "SCS results should be excluded for other agents")
+	}
+	assert.Assert(t, results.TotalCount == 7, "SCS Scorecard results should be excluded")
+
+	defer os.Remove(fileName + ".json")
+}
+
+func TestRunNilResults_Other_AgentsShouldNotShowAnyResults(t *testing.T) {
+	executeCommand := func(agent string) *wrappers.ScanResultsCollection {
+		clearFlags()
+		mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.SCSEngineCLIEnabled, Status: true}
+		mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.ContainerEngineCLIEnabled, Status: true}
+
+		_, err := executeRedirectedOsStdoutTestCommand(createASTTestCommand(),
+			"results", "show", "--scan-id", "NIL_RESULTS", "--report-format", "json", "--agent", agent)
+		assert.NilError(t, err)
+
+		file, err := os.Open(fileName + ".json")
+		if err != nil {
+			t.Fatalf("failed to open file: %v", err)
+		}
+		defer file.Close()
+
+		fileContents, err := io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+
+		var results wrappers.ScanResultsCollection
+		err = json.Unmarshal(fileContents, &results)
+		assert.NilError(t, err)
+		return &results
+	}
+
+	results := executeCommand("Jetbrains")
+
+	assert.Assert(t, results.TotalCount == 0, "SCS Scorecard results should be excluded")
+
+	defer os.Remove(fileName + ".json")
 }
 
 func TestResultsExitCode_OnCanceledScan_PrintOnlyScanIDAndStatusCanceledToConsole(t *testing.T) {

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -6,6 +6,7 @@ const (
 	AgentFlagUsage               = "Scan origin name"
 	ApplicationName              = "application-name"
 	DefaultAgent                 = "ASTCLI"
+	VSCodeAgent                  = "VS Code"
 	DebugFlag                    = "debug"
 	DebugUsage                   = "Debug mode with detailed logs"
 	RetryFlag                    = "retry"
@@ -230,20 +231,22 @@ const (
 
 // Results
 const (
-	SastType             = "sast"
-	KicsType             = "kics"
-	APISecurityType      = "api-security"
-	AIProtectionType     = "AI Protection"
-	ContainersType       = "containers"
-	APIDocumentationFlag = "apisec-swagger-filter"
-	IacType              = "iac-security"
-	IacLabel             = "IaC Security"
-	APISecurityLabel     = "API Security"
-	ScaType              = "sca"
-	APISecType           = "apisec"
-	ScsType              = "scs"
-	MicroEnginesType     = "microengines" // the scs scan type for scans API
-	Success              = "success"
+	SastType               = "sast"
+	KicsType               = "kics"
+	APISecurityType        = "api-security"
+	AIProtectionType       = "AI Protection"
+	ContainersType         = "containers"
+	APIDocumentationFlag   = "apisec-swagger-filter"
+	IacType                = "iac-security"
+	IacLabel               = "IaC Security"
+	APISecurityLabel       = "API Security"
+	ScaType                = "sca"
+	APISecType             = "apisec"
+	ScsType                = "scs"
+	MicroEnginesType       = "microengines" // the scs scan type for scans API
+	Success                = "success"
+	SCSScorecardType       = "sscs-Scorecard"
+	SCSSecretDetectionType = "sscs-Secret Detection"
 )
 
 // ScaAgent AST Role

--- a/internal/wrappers/mock/results-mock.go
+++ b/internal/wrappers/mock/results-mock.go
@@ -29,6 +29,40 @@ var containersResults = &wrappers.ScanResult{
 		CweID:     "CWE-1234",
 	},
 }
+var scsResults = &wrappers.ScanResultsCollection{
+	TotalCount: 2,
+	Results: []*wrappers.ScanResult{
+		{
+			Type:                 "sscs-Secret Detection",
+			ID:                   "bhXbZjjoQZdGAwUhj6MLo9sh4fA=",
+			SimilarityID:         "6deb156f325544aaefecee846b49a948571cecd4445d2b2b391a490641be5845",
+			Status:               "NEW",
+			State:                "TO_VERIFY",
+			Severity:             "HIGH",
+			Created:              "2024-07-30T12:49:56Z",
+			FirstFoundAt:         "2023-07-06T10:28:49Z",
+			FoundAt:              "2024-07-30T12:49:56Z",
+			FirstScanID:          "3d922bcd-00fe-4774-b182-d51e739dff81",
+			Description:          "Generic API Key has detected secret for file application.properties.",
+			VulnerabilityDetails: wrappers.VulnerabilityDetails{},
+		},
+		{
+			Type:         "sscs-Scorecard",
+			ID:           "n2a8iCzrIgbCe+dGKYk+cAApO0U=",
+			SimilarityID: "65323789a325544aaefecee846b49a948571cecd4445d2b2b391a490641be5845",
+			Status:       "NEW",
+			State:        "TO_VERIFY",
+			Severity:     "HIGH",
+			Created:      "2024-07-30T12:49:56Z",
+			FirstFoundAt: "2023-07-06T10:28:49Z",
+			FoundAt:      "2024-07-30T12:49:56Z",
+			FirstScanID:  "3d922bcd-00fe-4774-b182-d51e739dff81",
+			Description:  "score is 0: branch protection not enabled on development/release branches:\\nWarn: branch protection not enabled for branch 'main'",
+
+			VulnerabilityDetails: wrappers.VulnerabilityDetails{},
+		},
+	},
+}
 
 func (r ResultsMockWrapper) GetAllResultsByScanID(params map[string]string) (
 	*wrappers.ScanResultsCollection,
@@ -47,6 +81,15 @@ func (r ResultsMockWrapper) GetAllResultsByScanID(params map[string]string) (
 			Results: []*wrappers.ScanResult{
 				containersResults,
 			},
+		}, nil, nil
+	}
+	if params["scan-id"] == "SCS" {
+		return scsResults, nil, nil
+	}
+	if params["scan-id"] == "NIL_RESULTS" {
+		return &wrappers.ScanResultsCollection{
+			TotalCount: 0,
+			Results:    nil,
 		}, nil, nil
 	}
 	const mock = "mock"


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

Added full support for SCS engine results when scanning from the CLI.
Added partial support (only Secret Detection results) when scanning is done from VS Code
No other case SCS results are supported

### References

https://checkmarx.atlassian.net/browse/AST-63907

### Testing

Adding unit tests to test the following scenarios:
Scan from CLI - expect to receive all SCS engine results.
Scan from VS Code - expect to get only Secret Detection results.
Scan from another engine - expect to get no results from the SCS engine.
Scan without results from SCS.
Scan with NULL results.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used