### PR TITLE
Return correct exit code on failure (AST-57074)

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -211,7 +211,6 @@ func NewAstCLI(
 		chatCmd,
 	)
 
-	rootCmd.SilenceErrors = true
 	rootCmd.SilenceUsage = true
 	return rootCmd
 }

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -140,6 +140,13 @@ func TestFilterTagStateAndSeverityValues(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestCreateCommand_WithInvalidFlag_ShouldReturnExitCode1(t *testing.T) {
+	args := []string{"g"}
+	cmd := createASTTestCommand()
+	err := executeTestCommand(cmd, args...)
+	assert.Error(t, err, "unknown command \"g\" for \"cx\"")
+}
+
 func executeTestCommand(cmd *cobra.Command, args ...string) error {
 	fmt.Println("Executing command with args ", args)
 	cmd.SetArgs(args)


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

This change has been to ensure that users receive accurate exit codes,
the CLI will now display any errors that occur and exit with the appropriate exit code (e.g., 1 for errors, 0 for success). This allows users to effectively handle error conditions and automate tasks based on the CLI's exit status.

### References

https://checkmarx.atlassian.net/browse/AST-57074

### Testing

Verified that tasks now correctly return an exit code of "1" on error and "0" on success.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used