### PR TITLE
Exclude node modules folder from the scan. (AST-70022)

### DIFF
--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -1027,6 +1027,15 @@ func Test_isDirFiltered(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		},
+		{
+			name: "WhenNodeModulesExcluded_ReturnIsFilteredTrue",
+			args: args{
+				filename: "node_modules",
+				filters:  commonParams.BaseExcludeFilters,
+			},
+			want:    true,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		ttt := tt

--- a/internal/params/filters.go
+++ b/internal/params/filters.go
@@ -141,6 +141,7 @@ var BaseExcludeFilters = []string{
 	"!.vs",
 	"!.vscode",
 	"!.idea",
+	"!node_modules",
 }
 
 var KicsBaseFilters = []string{


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

The node modules directory has been excluded from the scan to optimize performance by reducing the number of files scanned." 

### References

https://checkmarx.atlassian.net/browse/AST-70022

### Testing

Add unit tests to check if the node modules directory is correctly filtered

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used