### PR TITLE
Remove default from unsupported agents for SCS results (AST-68004)

### DIFF
--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -1088,7 +1088,6 @@ func filterResultsByType(results *wrappers.ScanResultsCollection, excludedTypes 
 
 func filterScsResultsByAgent(results *wrappers.ScanResultsCollection, agent string) *wrappers.ScanResultsCollection {
 	unsupportedTypesByAgent := map[string][]string{
-		commonParams.DefaultAgent:      {},
 		commonParams.VSCodeAgent:       {commonParams.SCSScorecardType},
 		commonParams.JetbrainsAgent:    {commonParams.SCSScorecardType, commonParams.SCSSecretDetectionType},
 		commonParams.EclipseAgent:      {commonParams.SCSScorecardType, commonParams.SCSSecretDetectionType},

--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -1088,6 +1088,7 @@ func filterResultsByType(results *wrappers.ScanResultsCollection, excludedTypes 
 
 func filterScsResultsByAgent(results *wrappers.ScanResultsCollection, agent string) *wrappers.ScanResultsCollection {
 	unsupportedTypesByAgent := map[string][]string{
+
 		commonParams.VSCodeAgent:       {commonParams.SCSScorecardType},
 		commonParams.JetbrainsAgent:    {commonParams.SCSScorecardType, commonParams.SCSSecretDetectionType},
 		commonParams.EclipseAgent:      {commonParams.SCSScorecardType, commonParams.SCSSecretDetectionType},

--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -1088,7 +1088,6 @@ func filterResultsByType(results *wrappers.ScanResultsCollection, excludedTypes 
 
 func filterScsResultsByAgent(results *wrappers.ScanResultsCollection, agent string) *wrappers.ScanResultsCollection {
 	unsupportedTypesByAgent := map[string][]string{
-
 		commonParams.VSCodeAgent:       {commonParams.SCSScorecardType},
 		commonParams.JetbrainsAgent:    {commonParams.SCSScorecardType, commonParams.SCSSecretDetectionType},
 		commonParams.EclipseAgent:      {commonParams.SCSScorecardType, commonParams.SCSSecretDetectionType},


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

>Removed the DefaultAgent from the unsupportedTypesByAgent map in the filterScsResultsByAgent function because it supports all result types (SCSScorecardType and SCSSecretDetectionType). Since its exclusion list was empty, its presence in the map was redundant. This change simplifies the code without affecting functionality, as DefaultAgent never excluded any result types.

### References

>https://checkmarx.atlassian.net/browse/AST-68004

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used