### PR TITLE
Added support for rs files. (AST-68753)

### DIFF
--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -1210,6 +1210,7 @@ func TestFilterMatched(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			result := filterMatched(tt.filters, tt.fileName)
 			assert.Equal(t, tt.expected, result)

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -1178,3 +1178,32 @@ func TestValidateContainerImageFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterMatched(t *testing.T) {
+	tests := []struct {
+		name     string
+		filters  []string
+		fileName string
+		expected bool
+	}{
+		{
+			name:     "whenFileMatchesInclusionFilter_shouldReturnTrue",
+			filters:  []string{"*.go"},
+			fileName: "main.go",
+			expected: true,
+		},
+		{
+			name:     "whenFileNoMatchesInclusionFilter_shouldReturnFalse",
+			filters:  []string{"*.go"},
+			fileName: "main.py",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterMatched(tt.filters, tt.fileName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/params/filters.go
+++ b/internal/params/filters.go
@@ -135,6 +135,7 @@ var BaseIncludeFilters = []string{
 	"Podfile.lock",
 	"*.cmp",
 	"Directory.Packages.props",
+	"*.rs",
 }
 
 var BaseExcludeFilters = []string{


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

Added support for 'rs' files in scans.

### References

https://checkmarx.atlassian.net/browse/AST-68753

### Testing

Added a unit test to check the filter method.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used