### PR TITLE
Add Code Repository Flag & Support PR Decoration For GH/GL On-prem (AST-72979, AST-72975)

### DIFF
--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -18,7 +18,7 @@ jobs:
             exit 1
           fi
           
-          if ! [[ "$PR_TITLE" =~ \(AST-[0-9]+\)$ ]]; then
+          if ! [[ "$PR_TITLE" =~ \(AST-[0-9]+\)$ || "$PR_TITLE" =~ \(AST-[0-9]+(, AST-[0-9]+)*\)$ ]]; then
             echo "::error::PR title must contain a Jira ticket ID at the end in the format '(AST-XXXX)'."
             exit 1
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/bash@sha256:f8e48690d991e6814c81f063833176439e8f0d4bc1c5f0a47f94858dea3e4f44
+FROM cgr.dev/chainguard/bash@sha256:e1d16dec8d976859080d984167109b3557c2b6494f10be08147806b78bdef691
 USER nonroot
 
 COPY cx /app/bin/cx

--- a/go.mod
+++ b/go.mod
@@ -262,7 +262,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	helm.sh/helm/v3 v3.15.4 // indirect
+	helm.sh/helm/v3 v3.16.2 // indirect
 	k8s.io/api v0.30.3 // indirect
 	k8s.io/apiextensions-apiserver v0.30.3 // indirect
 	k8s.io/apimachinery v0.30.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Checkmarx/gen-ai-prompts v0.0.0-20240807143411-708ceec12b63
 	github.com/CheckmarxDev/containers-resolver v1.0.13
 	github.com/MakeNowJust/heredoc v1.0.0
+	github.com/bouk/monkey v1.0.0
 	github.com/checkmarxDev/gpt-wrapper v0.0.0-20230721160222-85da2fd1cc4c
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gomarkdown/markdown v0.0.0-20230922112808-5421fefb8386

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bouk/monkey v1.0.0
 	github.com/checkmarxDev/gpt-wrapper v0.0.0-20230721160222-85da2fd1cc4c
 	github.com/golang-jwt/jwt v3.2.2+incompatible
-	github.com/gomarkdown/markdown v0.0.0-20230922112808-5421fefb8386
+	github.com/gomarkdown/markdown v0.0.0-20241102151059-6bc1ffdc6e8c
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
 	github.com/gookit/color v1.5.4

--- a/go.mod
+++ b/go.mod
@@ -262,7 +262,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	helm.sh/helm/v3 v3.16.2 // indirect
+	helm.sh/helm/v3 v3.15.4 // indirect
 	k8s.io/api v0.30.3 // indirect
 	k8s.io/apiextensions-apiserver v0.30.3 // indirect
 	k8s.io/apimachinery v0.30.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,7 +159,6 @@ github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwN
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bouk/monkey v1.0.0 h1:k6z8fLlPhETfn5l9rlWVE7Q6B23DoaqosTdArvNQRdc=
 github.com/bouk/monkey v1.0.0/go.mod h1:PG/63f4XEUlVyW1ttIeOJmJhhe1+t9EC/je3eTjvFhE=
-github.com/bouk/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
@@ -432,8 +431,8 @@ github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gomarkdown/markdown v0.0.0-20230922112808-5421fefb8386 h1:EcQR3gusLHN46TAD+G+EbaaqJArt5vHhNpXAa12PQf4=
-github.com/gomarkdown/markdown v0.0.0-20230922112808-5421fefb8386/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/gomarkdown/markdown v0.0.0-20241102151059-6bc1ffdc6e8c h1:CrUrhyZMx1Me0fyvvFtQq6W18ss2WEfgPRfjnwrTtiQ=
+github.com/gomarkdown/markdown v0.0.0-20241102151059-6bc1ffdc6e8c/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/gomodule/redigo v1.8.2 h1:H5XSIre1MB5NbPYFp+i1NBbb5qN1W8Y8YAQoAYbkm8k=
 github.com/gomodule/redigo v1.8.2/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,9 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/bouk/monkey v1.0.0 h1:k6z8fLlPhETfn5l9rlWVE7Q6B23DoaqosTdArvNQRdc=
+github.com/bouk/monkey v1.0.0/go.mod h1:PG/63f4XEUlVyW1ttIeOJmJhhe1+t9EC/je3eTjvFhE=
+github.com/bouk/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=

--- a/internal/commands/util/pr.go
+++ b/internal/commands/util/pr.go
@@ -48,7 +48,7 @@ func NewPRDecorationCommand(prWrapper wrappers.PRWrapper, policyWrapper wrappers
 	return cmd
 }
 
-func isScanRunningOrQueued(scansWrapper wrappers.ScansWrapper, scanID string) (bool, error) {
+func IsScanRunningOrQueued(scansWrapper wrappers.ScansWrapper, scanID string) (bool, error) {
 	var scanResponseModel *wrappers.ScanResponseModel
 	var errorModel *wrappers.ErrorModel
 	var err error
@@ -168,7 +168,7 @@ func runPRDecoration(prWrapper wrappers.PRWrapper, policyWrapper wrappers.Policy
 		prNumberFlag, _ := cmd.Flags().GetInt(params.PRNumberFlag)
 		apiURL, _ := cmd.Flags().GetString(params.CodeRepositoryFlag)
 
-		scanRunningOrQueued, err := isScanRunningOrQueued(scansWrapper, scanID)
+		scanRunningOrQueued, err := IsScanRunningOrQueued(scansWrapper, scanID)
 
 		if err != nil {
 			return err
@@ -236,7 +236,7 @@ func runPRDecorationGitlab(prWrapper wrappers.PRWrapper, policyWrapper wrappers.
 		gitlabProjectIDFlag, _ := cmd.Flags().GetInt(params.PRGitlabProjectFlag)
 		apiURL, _ := cmd.Flags().GetString(params.CodeRepositoryFlag)
 
-		scanRunningOrQueued, err := isScanRunningOrQueued(scansWrapper, scanID)
+		scanRunningOrQueued, err := IsScanRunningOrQueued(scansWrapper, scanID)
 
 		if err != nil {
 			return err

--- a/internal/commands/util/pr.go
+++ b/internal/commands/util/pr.go
@@ -25,8 +25,8 @@ const (
 	noPRDecorationCreated            = "A PR couldn't be created for this scan because it is still in progress."
 	githubOnPremURLSuffix            = "/api/v3/repos/"
 	gitlabOnPremURLSuffix            = "/api/v4/"
-	githubCloudUrl                   = "https://api.github.com/repos/"
-	gitlabCloudUrl                   = "https://gitlab.com" + gitlabOnPremURLSuffix
+	githubCloudURL                   = "https://api.github.com/repos/"
+	gitlabCloudURL                   = "https://gitlab.com" + gitlabOnPremURLSuffix
 )
 
 func NewPRDecorationCommand(prWrapper wrappers.PRWrapper, policyWrapper wrappers.PolicyWrapper, scansWrapper wrappers.ScansWrapper) *cobra.Command {
@@ -186,7 +186,7 @@ func runPRDecoration(prWrapper wrappers.PRWrapper, policyWrapper wrappers.Policy
 		}
 
 		// Build and post the pr decoration
-		updatedApiURL := updateApiURLForGithubOnPrem(apiURL)
+		updatedAPIURL := updateAPIURLForGithubOnPrem(apiURL)
 
 		prModel := &wrappers.PRModel{
 			ScanID:    scanID,
@@ -195,7 +195,7 @@ func runPRDecoration(prWrapper wrappers.PRWrapper, policyWrapper wrappers.Policy
 			RepoName:  repoNameFlag,
 			PrNumber:  prNumberFlag,
 			Policies:  policies,
-			ApiURL:    updatedApiURL,
+			APIURL:    updatedAPIURL,
 		}
 		prResponse, errorModel, err := prWrapper.PostPRDecoration(prModel)
 		if err != nil {
@@ -212,18 +212,18 @@ func runPRDecoration(prWrapper wrappers.PRWrapper, policyWrapper wrappers.Policy
 	}
 }
 
-func updateApiURLForGithubOnPrem(apiURL string) string {
+func updateAPIURLForGithubOnPrem(apiURL string) string {
 	if apiURL != "" {
 		return apiURL + githubOnPremURLSuffix
 	}
-	return githubCloudUrl
+	return githubCloudURL
 }
 
-func updateApiURLForGitlabOnPrem(apiURL string) string {
+func updateAPIURLForGitlabOnPrem(apiURL string) string {
 	if apiURL != "" {
 		return apiURL + gitlabOnPremURLSuffix
 	}
-	return gitlabCloudUrl
+	return gitlabCloudURL
 }
 
 func runPRDecorationGitlab(prWrapper wrappers.PRWrapper, policyWrapper wrappers.PolicyWrapper, scansWrapper wrappers.ScansWrapper) func(cmd *cobra.Command, args []string) error {
@@ -254,7 +254,7 @@ func runPRDecorationGitlab(prWrapper wrappers.PRWrapper, policyWrapper wrappers.
 		}
 
 		// Build and post the mr decoration
-		updatedApiURL := updateApiURLForGitlabOnPrem(apiURL)
+		updatedAPIURL := updateAPIURLForGitlabOnPrem(apiURL)
 
 		prModel := &wrappers.GitlabPRModel{
 			ScanID:          scanID,
@@ -264,7 +264,7 @@ func runPRDecorationGitlab(prWrapper wrappers.PRWrapper, policyWrapper wrappers.
 			IiD:             iIDFlag,
 			GitlabProjectID: gitlabProjectIDFlag,
 			Policies:        policies,
-			ApiURL:          updatedApiURL,
+			APIURL:          updatedAPIURL,
 		}
 
 		prResponse, errorModel, err := prWrapper.PostGitlabPRDecoration(prModel)

--- a/internal/commands/util/pr_test.go
+++ b/internal/commands/util/pr_test.go
@@ -27,14 +27,14 @@ func TestNewMRDecorationCommandMustExist(t *testing.T) {
 func TestIsScanRunning_WhenScanRunning_ShouldReturnTrue(t *testing.T) {
 	scansMockWrapper := &mock.ScansMockWrapper{Running: true}
 
-	scanRunning, _ := isScanRunningOrQueued(scansMockWrapper, "ScanRunning")
+	scanRunning, _ := IsScanRunningOrQueued(scansMockWrapper, "ScanRunning")
 	asserts.True(t, scanRunning)
 }
 
 func TestIsScanRunning_WhenScanDone_ShouldReturnFalse(t *testing.T) {
 	scansMockWrapper := &mock.ScansMockWrapper{Running: false}
 
-	scanRunning, _ := isScanRunningOrQueued(scansMockWrapper, "ScanNotRunning")
+	scanRunning, _ := IsScanRunningOrQueued(scansMockWrapper, "ScanNotRunning")
 	asserts.False(t, scanRunning)
 }
 

--- a/internal/commands/util/pr_test.go
+++ b/internal/commands/util/pr_test.go
@@ -24,14 +24,14 @@ func TestNewMRDecorationCommandMustExist(t *testing.T) {
 	assert.ErrorContains(t, err, "scan-id")
 }
 
-func TestIfScanRunning_WhenScanRunning_ShouldReturnTrue(t *testing.T) {
+func TestIsScanRunning_WhenScanRunning_ShouldReturnTrue(t *testing.T) {
 	scansMockWrapper := &mock.ScansMockWrapper{Running: true}
 
 	scanRunning, _ := isScanRunningOrQueued(scansMockWrapper, "ScanRunning")
 	asserts.True(t, scanRunning)
 }
 
-func TestIfScanRunning_WhenScanDone_ShouldReturnFalse(t *testing.T) {
+func TestIsScanRunning_WhenScanDone_ShouldReturnFalse(t *testing.T) {
 	scansMockWrapper := &mock.ScansMockWrapper{Running: false}
 
 	scanRunning, _ := isScanRunningOrQueued(scansMockWrapper, "ScanNotRunning")

--- a/internal/commands/util/pr_test.go
+++ b/internal/commands/util/pr_test.go
@@ -44,3 +44,25 @@ func TestPRDecorationGithub_WhenNoViolatedPolicies_ShouldNotReturnPolicy(t *test
 	prPolicy := policiesToPrPolicies(policyResponse)
 	asserts.True(t, len(prPolicy) == 0)
 }
+
+func TestUpdateAPIURLForGithubOnPrem_whenAPIURLIsSet_ShouldUpdateAPIURL(t *testing.T) {
+	selfHostedURL := "https://github.example.com"
+	updatedAPIURL := updateAPIURLForGithubOnPrem(selfHostedURL)
+	asserts.Equal(t, selfHostedURL+githubOnPremURLSuffix, updatedAPIURL)
+}
+
+func TestUpdateAPIURLForGithubOnPrem_whenAPIURLIsNotSet_ShouldReturnCloudAPIURL(t *testing.T) {
+	cloudAPIURL := updateAPIURLForGithubOnPrem("")
+	asserts.Equal(t, githubCloudURL, cloudAPIURL)
+}
+
+func TestUpdateAPIURLForGitlabOnPrem_whenAPIURLIsSet_ShouldUpdateAPIURL(t *testing.T) {
+	selfHostedURL := "https://gitlab.example.com"
+	updatedAPIURL := updateAPIURLForGitlabOnPrem(selfHostedURL)
+	asserts.Equal(t, selfHostedURL+gitlabOnPremURLSuffix, updatedAPIURL)
+}
+
+func TestUpdateAPIURLForGitlabOnPrem_whenAPIURLIsNotSet_ShouldReturnCloudAPIURL(t *testing.T) {
+	cloudAPIURL := updateAPIURLForGitlabOnPrem("")
+	asserts.Equal(t, gitlabCloudURL, cloudAPIURL)
+}

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -33,6 +33,8 @@ const (
 	BranchFlag                   = "branch"
 	BranchFlagSh                 = "b"
 	ScanIDFlag                   = "scan-id"
+	CodeRepositoryFlag           = "code-repository-url"
+	CodeRepositoryFlagUsage      = "Code repository URL (optional for self-hosted Azure DevOps)"
 	BranchFlagUsage              = "Branch to scan"
 	MainBranchFlag               = "branch"
 	ScaResolverFlag              = "sca-resolver"

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -34,7 +34,7 @@ const (
 	BranchFlagSh                 = "b"
 	ScanIDFlag                   = "scan-id"
 	CodeRepositoryFlag           = "code-repository-url"
-	CodeRepositoryFlagUsage      = "Code repository URL (optional for self-hosted Azure DevOps)"
+	CodeRepositoryFlagUsage      = "Code repository URL (optional for self-hosted SCMs)"
 	BranchFlagUsage              = "Branch to scan"
 	MainBranchFlag               = "branch"
 	ScaResolverFlag              = "sca-resolver"

--- a/internal/wrappers/pr.go
+++ b/internal/wrappers/pr.go
@@ -11,6 +11,7 @@ type PRModel struct {
 	RepoName  string     `json:"repoName"`
 	PrNumber  int        `json:"prNumber"`
 	Policies  []PrPolicy `json:"violatedPolicyList"`
+	ApiURL    string     `json:"apiUrl"`
 }
 
 type GitlabPRModel struct {
@@ -21,6 +22,7 @@ type GitlabPRModel struct {
 	IiD             int        `json:"iid"`
 	GitlabProjectID int        `json:"gitlabProjectID"`
 	Policies        []PrPolicy `json:"violatedPolicyList"`
+	ApiURL          string     `json:"apiUrl"`
 }
 
 type PRWrapper interface {

--- a/internal/wrappers/pr.go
+++ b/internal/wrappers/pr.go
@@ -11,7 +11,7 @@ type PRModel struct {
 	RepoName  string     `json:"repoName"`
 	PrNumber  int        `json:"prNumber"`
 	Policies  []PrPolicy `json:"violatedPolicyList"`
-	ApiURL    string     `json:"apiUrl"`
+	APIURL    string     `json:"apiUrl"`
 }
 
 type GitlabPRModel struct {
@@ -22,7 +22,7 @@ type GitlabPRModel struct {
 	IiD             int        `json:"iid"`
 	GitlabProjectID int        `json:"gitlabProjectID"`
 	Policies        []PrPolicy `json:"violatedPolicyList"`
-	ApiURL          string     `json:"apiUrl"`
+	APIURL          string     `json:"apiUrl"`
 }
 
 type PRWrapper interface {

--- a/test/integration/pr_test.go
+++ b/test/integration/pr_test.go
@@ -76,7 +76,7 @@ func TestPRGithubDecorationSuccessCase(t *testing.T) {
 	assert.NilError(t, err, "Error should be nil")
 }
 
-func TestPRGithubOnPremDecorationSuccessCase(t *testing.T) {
+func TestPRGithubDecoration_WhenUseCodeRepositoryFlag_ShouldSuccess(t *testing.T) {
 	args := []string{
 		"utils",
 		"pr",
@@ -157,7 +157,7 @@ func TestPRGitlabDecorationSuccessCase(t *testing.T) {
 	assert.NilError(t, err, "Error should be nil")
 }
 
-func TestPRGitlabOnPremDecorationSuccessCase(t *testing.T) {
+func TestPRGitlabDecoration_WhenUseCodeRepositoryFlag_ShouldSuccess(t *testing.T) {
 	args := []string{
 		"utils",
 		"pr",

--- a/test/integration/pr_test.go
+++ b/test/integration/pr_test.go
@@ -79,7 +79,7 @@ func TestPRGithubOnPremDecorationSuccessCase(t *testing.T) {
 	monkey.Patch((*wrappers.PRHTTPWrapper).PostPRDecoration, func(*wrappers.PRHTTPWrapper, *wrappers.PRModel) (string, *wrappers.WebError, error) {
 		return githubPRCommentCreated, nil, nil
 	})
-	defer monkey.Unpatch(wrappers.PRWrapper.PostPRDecoration)
+	defer monkey.Unpatch((*wrappers.PRHTTPWrapper).PostPRDecoration)
 
 	file := createOutputFile(t, outputFileName)
 	defer deleteOutputFile(t, file)
@@ -166,7 +166,7 @@ func TestPRGitlabOnPremDecorationSuccessCase(t *testing.T) {
 	monkey.Patch((*wrappers.PRHTTPWrapper).PostPRDecoration, func(*wrappers.PRHTTPWrapper, *wrappers.GitlabPRModel) (string, *wrappers.WebError, error) {
 		return gitlabPRCommentCreated, nil, nil
 	})
-	defer monkey.Unpatch(wrappers.PRWrapper.PostPRDecoration)
+	defer monkey.Unpatch((*wrappers.PRHTTPWrapper).PostPRDecoration)
 
 	file := createOutputFile(t, outputFileName)
 	defer deleteOutputFile(t, file)

--- a/test/integration/pr_test.go
+++ b/test/integration/pr_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"github.com/checkmarx/ast-cli/internal/wrappers"
 	"os"
 	"strings"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/checkmarx/ast-cli/internal/commands/util"
 	"github.com/checkmarx/ast-cli/internal/logger"
 
+	"github.com/bouk/monkey"
 	"github.com/checkmarx/ast-cli/internal/params"
 	"gotest.tools/assert"
 )
@@ -26,6 +28,9 @@ const (
 	prGitlabIid                   = "PR_GITLAB_IID"
 	prdDecorationForbiddenMessage = "A PR couldn't be created for this scan because it is still in progress."
 	failedGettingScanError        = "Failed showing a scan"
+	githubPRCommentCreated        = "github PR comment created successfully."
+	gitlabPRCommentCreated        = "gitlab PR comment created successfully."
+	outputFileName                = "test_output.log"
 )
 
 func TestPRGithubDecorationSuccessCase(t *testing.T) {
@@ -49,6 +54,46 @@ func TestPRGithubDecorationSuccessCase(t *testing.T) {
 
 	err, _ := executeCommand(t, args...)
 	assert.NilError(t, err, "Error should be nil")
+}
+
+func TestPRGithubOnPremDecorationSuccessCase(t *testing.T) {
+	scanID, _ := getRootScan(t, params.SastType)
+	args := []string{
+		"utils",
+		"pr",
+		"github",
+		flag(params.ScanIDFlag),
+		scanID,
+		flag(params.SCMTokenFlag),
+		os.Getenv(prGithubToken),
+		flag(params.NamespaceFlag),
+		os.Getenv(prGithubNamespace),
+		flag(params.PRNumberFlag),
+		os.Getenv(prGithubNumber),
+		flag(params.RepoNameFlag),
+		os.Getenv(prGithubRepoName),
+		flag(params.CodeRepositoryFlag),
+		"https://github.example.com",
+	}
+
+	monkey.Patch((*wrappers.PRHTTPWrapper).PostPRDecoration, func(*wrappers.PRHTTPWrapper, *wrappers.PRModel) (string, *wrappers.WebError, error) {
+		return githubPRCommentCreated, nil, nil
+	})
+	defer monkey.Unpatch(wrappers.PRWrapper.PostPRDecoration)
+
+	file := createOutputFile(t, outputFileName)
+	defer deleteOutputFile(t, file)
+	defer logger.SetOutput(os.Stdout)
+
+	err, _ := executeCommand(t, args...)
+	assert.NilError(t, err, "Error should be nil")
+
+	stdoutString, err := util.ReadFileAsString(file.Name())
+	if err != nil {
+		t.Fatalf("Failed to read log file: %v", err)
+	}
+
+	assert.Equal(t, strings.Contains(stdoutString, githubPRCommentCreated), true, "Expected output: %s", githubPRCommentCreated)
 }
 
 func TestPRGithubDecorationFailure(t *testing.T) {
@@ -95,6 +140,49 @@ func TestPRGitlabDecorationSuccessCase(t *testing.T) {
 	assert.NilError(t, err, "Error should be nil")
 }
 
+func TestPRGitlabOnPremDecorationSuccessCase(t *testing.T) {
+	scanID, _ := getRootScan(t, params.SastType)
+
+	args := []string{
+		"utils",
+		"pr",
+		"gitlab",
+		flag(params.ScanIDFlag),
+		scanID,
+		flag(params.SCMTokenFlag),
+		os.Getenv(prGitlabToken),
+		flag(params.NamespaceFlag),
+		os.Getenv(prGitlabNamespace),
+		flag(params.RepoNameFlag),
+		os.Getenv(prGitlabRepoName),
+		flag(params.PRGitlabProjectFlag),
+		os.Getenv(prGitlabProjectId),
+		flag(params.PRIidFlag),
+		os.Getenv(prGitlabIid),
+		flag(params.CodeRepositoryFlag),
+		"https://gitlab.example.com",
+	}
+
+	monkey.Patch((*wrappers.PRHTTPWrapper).PostPRDecoration, func(*wrappers.PRHTTPWrapper, *wrappers.GitlabPRModel) (string, *wrappers.WebError, error) {
+		return gitlabPRCommentCreated, nil, nil
+	})
+	defer monkey.Unpatch(wrappers.PRWrapper.PostPRDecoration)
+
+	file := createOutputFile(t, outputFileName)
+	defer deleteOutputFile(t, file)
+	defer logger.SetOutput(os.Stdout)
+
+	err, _ := executeCommand(t, args...)
+	assert.NilError(t, err, "Error should be nil")
+
+	stdoutString, err := util.ReadFileAsString(file.Name())
+	if err != nil {
+		t.Fatalf("Failed to read log file: %v", err)
+	}
+
+	assert.Equal(t, strings.Contains(stdoutString, gitlabPRCommentCreated), true, "Expected output: %s", gitlabPRCommentCreated)
+}
+
 func TestPRGitlabDecorationFailure(t *testing.T) {
 
 	args := []string{
@@ -137,7 +225,7 @@ func TestPRGithubDecoration_WhenScanIsRunning_ShouldAvoidPRDecorationCommand(t *
 		"--debug",
 	}
 
-	file := createOutputFile(t, "test_output.log")
+	file := createOutputFile(t, outputFileName)
 	_, _ = executeCommand(t, args...)
 	stdoutString, err := util.ReadFileAsString(file.Name())
 	if err != nil {
@@ -169,7 +257,7 @@ func TestPRGitlabDecoration_WhenScanIsRunning_ShouldAvoidPRDecorationCommand(t *
 		os.Getenv(prGitlabIid),
 	}
 
-	file := createOutputFile(t, "test_output.log")
+	file := createOutputFile(t, outputFileName)
 	_, _ = executeCommand(t, args...)
 	stdoutString, err := util.ReadFileAsString(file.Name())
 	if err != nil {

--- a/test/integration/pr_test.go
+++ b/test/integration/pr_test.go
@@ -163,10 +163,10 @@ func TestPRGitlabOnPremDecorationSuccessCase(t *testing.T) {
 		"https://gitlab.example.com",
 	}
 
-	monkey.Patch((*wrappers.PRHTTPWrapper).PostPRDecoration, func(*wrappers.PRHTTPWrapper, *wrappers.GitlabPRModel) (string, *wrappers.WebError, error) {
+	monkey.Patch((*wrappers.PRHTTPWrapper).PostGitlabPRDecoration, func(*wrappers.PRHTTPWrapper, *wrappers.GitlabPRModel) (string, *wrappers.WebError, error) {
 		return gitlabPRCommentCreated, nil, nil
 	})
-	defer monkey.Unpatch((*wrappers.PRHTTPWrapper).PostPRDecoration)
+	defer monkey.Unpatch((*wrappers.PRHTTPWrapper).PostGitlabPRDecoration)
 
 	file := createOutputFile(t, outputFileName)
 	defer deleteOutputFile(t, file)

--- a/test/integration/pr_test.go
+++ b/test/integration/pr_test.go
@@ -180,7 +180,8 @@ func TestPRGitlabOnPremDecorationSuccessCase(t *testing.T) {
 		t.Fatalf("Failed to read log file: %v", err)
 	}
 
-	assert.Equal(t, strings.Contains(stdoutString, gitlabPRCommentCreated), true, "Expected output: %s", gitlabPRCommentCreated)
+	assert.Equal(t, strings.Contains(stdoutString, gitlabPRCommentCreated), true, "Expected output: %s", gitlabPRCommentCreated, " | actual: ", stdoutString)
+
 }
 
 func TestPRGitlabDecorationFailure(t *testing.T) {

--- a/test/integration/pr_test.go
+++ b/test/integration/pr_test.go
@@ -44,6 +44,10 @@ func getCompletedScanID(t *testing.T) string {
 	scanWrapper := wrappers.NewHTTPScansWrapper(scans)
 	scanID, _ := getRootScan(t, params.IacType)
 
+	file := createOutputFile(t, outputFileName)
+	defer deleteOutputFile(t, file)
+	defer logger.SetOutput(os.Stdout)
+
 	for isRunning, err := util.IsScanRunningOrQueued(scanWrapper, scanID); isRunning; isRunning, err = util.IsScanRunningOrQueued(scanWrapper, scanID) {
 		if err != nil {
 			t.Fatalf("Failed to get scan status: %v", err)
@@ -55,12 +59,13 @@ func getCompletedScanID(t *testing.T) string {
 }
 
 func TestPRGithubDecorationSuccessCase(t *testing.T) {
+	scanID := getCompletedScanID(t)
 	args := []string{
 		"utils",
 		"pr",
 		"github",
 		flag(params.ScanIDFlag),
-		getCompletedScanID(t),
+		scanID,
 		flag(params.SCMTokenFlag),
 		os.Getenv(prGithubToken),
 		flag(params.NamespaceFlag),

--- a/test/integration/pr_test.go
+++ b/test/integration/pr_test.go
@@ -59,7 +59,7 @@ func getCompletedScanID(t *testing.T) string {
 }
 
 func TestPRGithubDecorationSuccessCase(t *testing.T) {
-	scanID := getCompletedScanID(t)
+	scanID, _ := getRootScan(t, params.SastType)
 	args := []string{
 		"utils",
 		"pr",
@@ -141,12 +141,13 @@ func TestPRGithubDecorationFailure(t *testing.T) {
 }
 
 func TestPRGitlabDecorationSuccessCase(t *testing.T) {
+	scanID, _ := getRootScan(t, params.SastType)
 	args := []string{
 		"utils",
 		"pr",
 		"gitlab",
 		flag(params.ScanIDFlag),
-		getCompletedScanID(t),
+		scanID,
 		flag(params.SCMTokenFlag),
 		os.Getenv(prGitlabToken),
 		flag(params.NamespaceFlag),

--- a/test/integration/root_test.go
+++ b/test/integration/root_test.go
@@ -47,6 +47,7 @@ var rootProjectName string
 func TestMain(m *testing.M) {
 	log.Println("CLI integration tests started")
 	viper.SetDefault(resolverEnvVar, resolverEnvVarDefault)
+	getRootScan(testInstance, commonParams.IacType)
 	exitVal := m.Run()
 	//deleteScanAndProject()
 	log.Println("CLI integration tests done")

--- a/test/integration/root_test.go
+++ b/test/integration/root_test.go
@@ -47,7 +47,6 @@ var rootProjectName string
 func TestMain(m *testing.M) {
 	log.Println("CLI integration tests started")
 	viper.SetDefault(resolverEnvVar, resolverEnvVarDefault)
-	getRootScan(testInstance, commonParams.IacType)
 	exitVal := m.Run()
 	//deleteScanAndProject()
 	log.Println("CLI integration tests done")


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> 1. add code-repository-url optional flag
> 2. support PR decoration command for github & gitlab on-prem

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> unit test for the new optional flag
>
> manually E2E tests on on-prem machines

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used