### PR TITLE
Remove from system  sca json file when using scan create with scaResolver (AST-48074)

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1356,6 +1356,7 @@ func runScaResolver(sourceDir, scaResolver, scaResolverParams, projectName strin
 		if err != nil {
 			return errors.Errorf("%s", err)
 		}
+		_ = os.Remove(scaFile.Name())
 	}
 	return nil
 }

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -4,6 +4,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -1186,4 +1187,18 @@ func TestValidateContainerImageFormat(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunScaResolverFileCleanup(t *testing.T) {
+	sourceDir := "/mock/sourceDir"
+	scaResolver := "/bin/echo"
+	scaResolverParams := ""
+	projectName := "testProject"
+
+	err := runScaResolver(sourceDir, scaResolver, scaResolverParams, projectName)
+
+	assert.NilError(t, err)
+
+	_, err = os.Stat(scaResolverResultsFile)
+	assert.Assert(t, os.IsNotExist(err), "Expected temp file to be deleted, but it exists")
 }


### PR DESCRIPTION
…lver

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> File Removal Logic: Added _ = os.Remove(scaFile.Name()) at the end of the function to ensure the temporary file created by ioutil.TempFile is deleted after the scan completes.

### References

> https://checkmarx.atlassian.net/browse/AST-48074

### Testing

> Unit Test (TestRunScaResolverFileCleanup)
Mock Setup: Defined mock values for sourceDir, scaResolver, and projectName.
Function Execution: Called runScaResolver with the mock inputs.
File Deletion Check: Verified that the temporary file was deleted using os.Stat and os.IsNotExist, ensuring that the cleanup process worked as expected.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used