### PR TITLE
CLI | Improve Performance In Results Show Command (AST-70015)

### DIFF
--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -1137,7 +1137,7 @@ func CreateScanReport(
 
 	err = createDirectory(targetPath)
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 	if !scanPending {
 		results, err = ReadResults(resultsWrapper, exportWrapper, scan, resultsParams, agent)

--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -960,6 +960,9 @@ func runGetResultCommand(
 		sastRedundancy, _ := cmd.Flags().GetBool(commonParams.SastRedundancyFlag)
 		agent, _ := cmd.Flags().GetString(commonParams.AgentFlag)
 		scaHideDevAndTestDep, _ := cmd.Flags().GetBool(commonParams.ScaHideDevAndTestDepFlag)
+		ignorePolicy, _ := cmd.Flags().GetBool(commonParams.IgnorePolicyFlag)
+		waitDelay, _ := cmd.Flags().GetInt(commonParams.WaitDelayFlag)
+		policyTimeout, _ := cmd.Flags().GetInt(commonParams.PolicyTimeoutFlag)
 
 		scanID, _ := cmd.Flags().GetString(commonParams.ScanIDFlag)
 		if scanID == "" {
@@ -983,7 +986,7 @@ func runGetResultCommand(
 			return errors.Errorf("%s: CODE: %d, %s", failedGettingScan, errorModel.Code, errorModel.Message)
 		}
 
-		policyResponseModel, err := services.HandlePolicyEvaluation(cmd, policyWrapper, scan)
+		policyResponseModel, err := services.HandlePolicyEvaluation(cmd, policyWrapper, scan, ignorePolicy, agent, waitDelay, policyTimeout)
 		if err != nil {
 			return err
 		}

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1682,7 +1682,10 @@ func runCreateScanCommand(
 				return err
 			}
 
-			policyResponseModel, err = services.HandlePolicyEvaluation(cmd, policyWrapper, scanResponseModel)
+			agent, _ := cmd.Flags().GetString(commonParams.AgentFlag)
+			ignorePolicy, _ := cmd.Flags().GetBool(commonParams.IgnorePolicyFlag)
+			policyTimeout, _ := cmd.Flags().GetInt(commonParams.PolicyTimeoutFlag)
+			policyResponseModel, err = services.HandlePolicyEvaluation(cmd, policyWrapper, scanResponseModel, ignorePolicy, agent, waitDelay, policyTimeout)
 			if err != nil {
 				return err
 			}

--- a/internal/services/policy-management.go
+++ b/internal/services/policy-management.go
@@ -1,0 +1,41 @@
+package services
+
+import (
+	"slices"
+
+	"github.com/checkmarx/ast-cli/internal/commands/policymanagement"
+	"github.com/checkmarx/ast-cli/internal/logger"
+	commonParams "github.com/checkmarx/ast-cli/internal/params"
+	"github.com/checkmarx/ast-cli/internal/wrappers"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var noPolicyEvaluatingIDEs = []string{commonParams.EclipseAgent, commonParams.JetbrainsAgent, commonParams.VSCodeAgent, commonParams.VisualStudioAgent}
+
+func HandlePolicyEvaluation(cmd *cobra.Command, policyWrapper wrappers.PolicyWrapper, scan *wrappers.ScanResponseModel) (*wrappers.PolicyResponseModel, error) {
+	policyResponseModel := &wrappers.PolicyResponseModel{}
+	policyOverrideFlag, _ := cmd.Flags().GetBool(commonParams.IgnorePolicyFlag)
+	waitDelay, _ := cmd.Flags().GetInt(commonParams.WaitDelayFlag)
+	agent := getAgent(cmd)
+
+	if policyOverrideFlag || slices.Contains(noPolicyEvaluatingIDEs, agent) {
+		logger.PrintIfVerbose("Skipping policy evaluation")
+		return policyResponseModel, nil
+	}
+
+	policyTimeout, _ := cmd.Flags().GetInt(commonParams.PolicyTimeoutFlag)
+	if policyTimeout < 0 {
+		return nil, errors.Errorf("--%s should be equal or higher than 0", commonParams.PolicyTimeoutFlag)
+	}
+
+	return policymanagement.HandlePolicyWait(waitDelay, policyTimeout, policyWrapper, scan.ID, scan.ProjectID, cmd)
+}
+
+func getAgent(cmd *cobra.Command) string {
+	agent, _ := cmd.Flags().GetString(commonParams.AgentFlag)
+	if agent == "" {
+		return commonParams.DefaultAgent
+	}
+	return agent
+}

--- a/internal/services/policy-management.go
+++ b/internal/services/policy-management.go
@@ -13,7 +13,8 @@ import (
 
 var noPolicyEvaluatingIDEs = []string{commonParams.EclipseAgent, commonParams.JetbrainsAgent, commonParams.VSCodeAgent, commonParams.VisualStudioAgent}
 
-func HandlePolicyEvaluation(cmd *cobra.Command, policyWrapper wrappers.PolicyWrapper, scan *wrappers.ScanResponseModel, ignorePolicy bool, agent string, waitDelay, policyTimeout int) (*wrappers.PolicyResponseModel, error) {
+func HandlePolicyEvaluation(cmd *cobra.Command, policyWrapper wrappers.PolicyWrapper, scan *wrappers.ScanResponseModel,
+	ignorePolicy bool, agent string, waitDelay, policyTimeout int) (*wrappers.PolicyResponseModel, error) {
 	policyResponseModel := &wrappers.PolicyResponseModel{}
 
 	if ignorePolicy || slices.Contains(noPolicyEvaluatingIDEs, agent) {

--- a/internal/services/policy-management_test.go
+++ b/internal/services/policy-management_test.go
@@ -1,34 +1,137 @@
 package services
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/checkmarx/ast-cli/internal/params"
 	"github.com/checkmarx/ast-cli/internal/wrappers"
+	"github.com/checkmarx/ast-cli/internal/wrappers/mock"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	scanWrapper       = mock.ScansMockWrapper{}
+	scanResults, _, _ = scanWrapper.GetByID("1234")
+	policyWrapper     = &mock.PolicyMockWrapper{}
+	policyModel, _, _ = policyWrapper.EvaluatePolicy(map[string]string{})
+)
+
 func TestHandlePolicyEvaluation(t *testing.T) {
-	type args struct {
-		cmd           *cobra.Command
-		policyWrapper wrappers.PolicyWrapper
-		scan          *wrappers.ScanResponseModel
-		agent         string
+	commonArgs := args{
+		cmd:           &cobra.Command{},
+		policyWrapper: policyWrapper,
+		scan:          scanResults,
+		ignorePolicy:  false,
+		waitDelay:     1,
+		policyTimeout: 1,
 	}
-	tests := []struct {
-		name    string
-		args    args
-		want    *wrappers.PolicyResponseModel
-		wantErr assert.ErrorAssertionFunc
-	}{}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := HandlePolicyEvaluation(tt.args.cmd, tt.args.policyWrapper, tt.args.scan)
-			if !tt.wantErr(t, err, fmt.Sprintf("HandlePolicyEvaluation(%v, %v, %v, %v)", tt.args.cmd, tt.args.policyWrapper, tt.args.scan, tt.args.agent)) {
-				return
+
+	testCases := []struct {
+		name        string
+		args        args
+		expected    *wrappers.PolicyResponseModel
+		expectError bool
+	}{
+		{
+			name: "DefaultAgent_Success",
+			args: args{
+				cmd:           commonArgs.cmd,
+				policyWrapper: commonArgs.policyWrapper,
+				scan:          commonArgs.scan,
+				ignorePolicy:  commonArgs.ignorePolicy,
+				agent:         params.DefaultAgent,
+				waitDelay:     commonArgs.waitDelay,
+				policyTimeout: commonArgs.policyTimeout,
+			},
+			expected:    policyModel,
+			expectError: false,
+		},
+		{
+			name: "EclipseAgent_NoPolicyEvaluation",
+			args: args{
+				cmd:           commonArgs.cmd,
+				policyWrapper: commonArgs.policyWrapper,
+				scan:          commonArgs.scan,
+				ignorePolicy:  commonArgs.ignorePolicy,
+				agent:         params.EclipseAgent,
+				waitDelay:     commonArgs.waitDelay,
+				policyTimeout: commonArgs.policyTimeout,
+			},
+			expected:    &wrappers.PolicyResponseModel{},
+			expectError: false,
+		},
+		{
+			name: "VSCodeAgent_NoPolicyEvaluation",
+			args: args{
+				cmd:           commonArgs.cmd,
+				policyWrapper: commonArgs.policyWrapper,
+				scan:          commonArgs.scan,
+				ignorePolicy:  commonArgs.ignorePolicy,
+				agent:         params.VSCodeAgent,
+				waitDelay:     commonArgs.waitDelay,
+				policyTimeout: commonArgs.policyTimeout,
+			},
+			expected:    &wrappers.PolicyResponseModel{},
+			expectError: false,
+		},
+		{
+			name: "VisualStudioAgent_NoPolicyEvaluation",
+			args: args{
+				cmd:           commonArgs.cmd,
+				policyWrapper: commonArgs.policyWrapper,
+				scan:          commonArgs.scan,
+				ignorePolicy:  commonArgs.ignorePolicy,
+				agent:         params.VisualStudioAgent,
+				waitDelay:     commonArgs.waitDelay,
+				policyTimeout: commonArgs.policyTimeout,
+			},
+			expected:    &wrappers.PolicyResponseModel{},
+			expectError: false,
+		},
+		{
+			name: "JetbrainsAgent_NoPolicyEvaluation",
+			args: args{
+				cmd:           commonArgs.cmd,
+				policyWrapper: commonArgs.policyWrapper,
+				scan:          commonArgs.scan,
+				ignorePolicy:  commonArgs.ignorePolicy,
+				agent:         params.JetbrainsAgent,
+				waitDelay:     commonArgs.waitDelay,
+				policyTimeout: commonArgs.policyTimeout,
+			},
+			expected:    &wrappers.PolicyResponseModel{},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := HandlePolicyEvaluation(
+				tc.args.cmd,
+				tc.args.policyWrapper,
+				tc.args.scan,
+				tc.args.ignorePolicy,
+				tc.args.agent,
+				tc.args.waitDelay,
+				tc.args.policyTimeout,
+			)
+			assert.Equal(t, tc.expected, result)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
-			assert.Equalf(t, tt.want, got, "HandlePolicyEvaluation(%v, %v, %v, %v)", tt.args.cmd, tt.args.policyWrapper, tt.args.scan, tt.args.agent)
 		})
 	}
+}
+
+type args struct {
+	cmd           *cobra.Command
+	policyWrapper wrappers.PolicyWrapper
+	scan          *wrappers.ScanResponseModel
+	ignorePolicy  bool
+	agent         string
+	waitDelay     int
+	policyTimeout int
 }

--- a/internal/services/policy-management_test.go
+++ b/internal/services/policy-management_test.go
@@ -106,6 +106,7 @@ func TestHandlePolicyEvaluation(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := HandlePolicyEvaluation(
 				tc.args.cmd,

--- a/internal/services/policy-management_test.go
+++ b/internal/services/policy-management_test.go
@@ -1,0 +1,34 @@
+package services
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/checkmarx/ast-cli/internal/wrappers"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandlePolicyEvaluation(t *testing.T) {
+	type args struct {
+		cmd           *cobra.Command
+		policyWrapper wrappers.PolicyWrapper
+		scan          *wrappers.ScanResponseModel
+		agent         string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *wrappers.PolicyResponseModel
+		wantErr assert.ErrorAssertionFunc
+	}{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := HandlePolicyEvaluation(tt.args.cmd, tt.args.policyWrapper, tt.args.scan)
+			if !tt.wantErr(t, err, fmt.Sprintf("HandlePolicyEvaluation(%v, %v, %v, %v)", tt.args.cmd, tt.args.policyWrapper, tt.args.scan, tt.args.agent)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "HandlePolicyEvaluation(%v, %v, %v, %v)", tt.args.cmd, tt.args.policyWrapper, tt.args.scan, tt.args.agent)
+		})
+	}
+}


### PR DESCRIPTION
remove second call to export service in calculating threshold

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Optimize threshold calculation to use the results we are getting in the beginning, instead of getting the results all over again.
> Skip policy evaluation when agent is and IDE agent

### References

> https://checkmarx.atlassian.net/browse/AST-70015

### Testing

> added unit tests

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used