### PR TITLE
Error message for SCS and Enterprise Secret (AST-73370)

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1064,13 +1064,6 @@ func validateScanTypes(cmd *cobra.Command, jwtWrapper wrappers.JWTWrapper, featu
 		userScanTypes = strings.Replace(strings.ToLower(userScanTypes), commonParams.ContainersTypeFlag, commonParams.ContainersType, 1)
 		userSCSScanTypes = strings.Replace(strings.ToLower(userSCSScanTypes), commonParams.SCSEnginesFlag, commonParams.ScsType, 1)
 
-		SCSScanTypes = strings.Split(userSCSScanTypes, ",")
-		if slices.Contains(SCSScanTypes, ScsSecretDetectionType) && !allowedEngines[commonParams.EnterpriseSecretsType] {
-			keys := reflect.ValueOf(allowedEngines).MapKeys()
-			err = errors.Errorf(engineNotAllowed, ScsSecretDetectionType, ScsSecretDetectionType, keys)
-			return err
-		}
-
 		scanTypes = strings.Split(userScanTypes, ",")
 		for _, scanType := range scanTypes {
 			if !allowedEngines[scanType] || (scanType == commonParams.ContainersType && !(containerEngineCLIEnabled.Status)) {
@@ -1079,6 +1072,14 @@ func validateScanTypes(cmd *cobra.Command, jwtWrapper wrappers.JWTWrapper, featu
 				return err
 			}
 		}
+
+		SCSScanTypes = strings.Split(userSCSScanTypes, ",")
+		if slices.Contains(SCSScanTypes, ScsSecretDetectionType) && !allowedEngines[commonParams.EnterpriseSecretsType] {
+			keys := reflect.ValueOf(allowedEngines).MapKeys()
+			err = errors.Errorf(engineNotAllowed, ScsSecretDetectionType, ScsSecretDetectionType, keys)
+			return err
+		}
+
 	} else {
 		for k := range allowedEngines {
 			if k == commonParams.ContainersType && !(containerEngineCLIEnabled.Status) {

--- a/internal/wrappers/mock/jwt-helper-mock.go
+++ b/internal/wrappers/mock/jwt-helper-mock.go
@@ -7,13 +7,17 @@ import (
 )
 
 type JWTMockWrapper struct {
-	AIEnabled int
+	AIEnabled               int
+	CustomGetAllowedEngines func(wrappers.FeatureFlagsWrapper) (map[string]bool, error)
 }
 
 const AIProtectionDisabled = 1
 
 // GetAllowedEngines mock for tests
-func (*JWTMockWrapper) GetAllowedEngines(featureFlagsWrapper wrappers.FeatureFlagsWrapper) (allowedEngines map[string]bool, err error) {
+func (j *JWTMockWrapper) GetAllowedEngines(featureFlagsWrapper wrappers.FeatureFlagsWrapper) (allowedEngines map[string]bool, err error) {
+	if j.CustomGetAllowedEngines != nil {
+		return j.CustomGetAllowedEngines(featureFlagsWrapper)
+	}
 	allowedEngines = make(map[string]bool)
 	engines := []string{"sast", "iac-security", "sca", "api-security", "containers", "scs"}
 	for _, value := range engines {


### PR DESCRIPTION
**Description**
This PR addresses the issue of handling feature flags and allowed engines in the JWTMockWrapper and JWTStruct implementations. It includes the following changes:  
Added a new mock for GetAllowedEngines to work with different engines set in tests.

Updated the GetAllowedEngines method in JWTStruct to handle feature flags and return the correct allowed engines.
Added unit tests to validate the behavior of the new mock and the updated GetAllowedEngines method.

**References**
Include supporting link to GitHub Issue/PR number  

**Testing**
This change was tested by adding unit tests for the GetAllowedEngines method and the new mock implementation. The tests cover various scenarios to ensure the correct engines are returned based on the feature flags and JWT token data. All existing tests were run to ensure no regressions were introduced.