### PR TITLE
Allow alternate $HOME to be used by CLI to support run inside JFrog artifactory plugin

### DIFF
--- a/internal/wrappers/configuration/configuration.go
+++ b/internal/wrappers/configuration/configuration.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/user"
 	"strings"
 
 	"github.com/checkmarx/ast-cli/internal/params"
@@ -118,11 +117,11 @@ func SetConfigProperty(propName, propValue string) {
 }
 
 func LoadConfiguration() {
-	usr, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		log.Fatal("Cannot file home directory.", err)
+		log.Fatal("Cannot find home directory.", err)
 	}
-	fullPath := usr.HomeDir + configDirName
+	fullPath := homeDir + configDirName
 	verifyConfigDir(fullPath)
 	viper.AddConfigPath(fullPath)
 	configFile := "checkmarxcli"
@@ -201,11 +200,11 @@ func SaveConfig(path string, config map[string]interface{}) error {
 }
 
 func GetConfigFilePath() (string, error) {
-	usr, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("error getting current user: %w", err)
+		return "", fmt.Errorf("error getting user home directory: %w", err)
 	}
-	return usr.HomeDir + configDirName + "/checkmarxcli.yaml", nil
+	return homeDir + configDirName + "/checkmarxcli.yaml", nil
 }
 
 func verifyConfigDir(fullPath string) {
@@ -213,7 +212,7 @@ func verifyConfigDir(fullPath string) {
 		fmt.Println("Creating directory")
 		err = os.Mkdir(fullPath, homeDirectoryPermissions)
 		if err != nil {
-			log.Fatal("Cannot file home directory.", err)
+			log.Fatal("Cannot create home directory.", err)
 		}
 	}
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> When running inside JFROG artifactory $HOME is wrong so clio is failing on creating the .checkmarx folder
> We changed from user.HomeDir to os.UserHomeDir()
> On Unix: user.HomeDir might read from /etc/passwd while os.UserHomeDir() uses $HOME
On Windows: Both generally use similar APIs but os.UserHomeDir() is more direct


Recommendation:

os.UserHomeDir() is preferred since Go 1.12 unless you specifically need other user information
It's simpler, more efficient, and handles edge cases better
> 

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Tried to override the $HOME and saw that CLI was creating directory in the right place

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used