### PR TITLE
CLI | Fix fast scan and incremental scan initialization in SAST configuration (AST-79107, AST-80586, AST-80553)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM checkmarx/bash:5.2.37-r2-737d21762d3388@sha256:631b3b846c1744ff5ddc7114f8df0eaf771f0e8bea3acea05155e8e0caa8532e
+FROM checkmarx/bash:5.2.37-r2-737d21762d3388@sha256:737d21762d3388d14fd47973cd2e6c1505fd1942b5347c07c7dd8de3305cbbee
 USER nonroot
 
 COPY cx /app/bin/cx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/bash@sha256:1abc09ac352efdc60d855bd159b9b66df6596a174400752ae3c537b5350779a9
+FROM checkmarx/bash:5.2.37-r2-737d21762d3388@sha256:631b3b846c1744ff5ddc7114f8df0eaf771f0e8bea3acea05155e8e0caa8532e
 USER nonroot
 
 COPY cx /app/bin/cx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM checkmarx/bash:5.2.37-r2-737d21762d3388@sha256:737d21762d3388d14fd47973cd2e6c1505fd1942b5347c07c7dd8de3305cbbee
+FROM checkmarx/bash:5.2.37-r2
 USER nonroot
 
 COPY cx /app/bin/cx

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -849,24 +849,27 @@ func addSastScan(cmd *cobra.Command, resubmitConfig []wrappers.Config) map[strin
 			continue
 		}
 
-		overrideSastConfigValue(&sastConfig, config)
+		overrideSastConfigValue(cmd, &sastConfig, config)
 	}
 
 	sastMapConfig[resultsMapValue] = &sastConfig
 	return sastMapConfig
 }
 
-func overrideSastConfigValue(sastConfig *wrappers.SastConfig, config wrappers.Config) {
+func overrideSastConfigValue(cmd *cobra.Command, sastConfig *wrappers.SastConfig, config wrappers.Config) {
 	setIfEmpty := func(configValue *string, resubmitValue interface{}) {
 		if *configValue == "" && resubmitValue != nil {
 			*configValue = resubmitValue.(string)
 		}
 	}
 
-	if resubmitIncremental := config.Value[configIncremental]; resubmitIncremental != nil {
+	sastFastScanChanged := cmd.Flags().Changed(commonParams.SastFastScanFlag)
+	sastIncrementalChanged := cmd.Flags().Changed(commonParams.IncrementalSast)
+
+	if resubmitIncremental := config.Value[configIncremental]; resubmitIncremental != nil && !sastIncrementalChanged {
 		sastConfig.Incremental = resubmitIncremental.(string)
 	}
-	if resubmitFastScan := config.Value[configFastScan]; resubmitFastScan != nil {
+	if resubmitFastScan := config.Value[configFastScan]; resubmitFastScan != nil && !sastFastScanChanged {
 		sastConfig.FastScanMode = resubmitFastScan.(string)
 	}
 

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -849,22 +849,19 @@ func addSastScan(cmd *cobra.Command, resubmitConfig []wrappers.Config) map[strin
 			continue
 		}
 
-		overrideSastConfigValue(cmd, &sastConfig, config)
+		overrideSastConfigValue(sastFastScanChanged, sastIncrementalChanged, &sastConfig, config)
 	}
 
 	sastMapConfig[resultsMapValue] = &sastConfig
 	return sastMapConfig
 }
 
-func overrideSastConfigValue(cmd *cobra.Command, sastConfig *wrappers.SastConfig, config wrappers.Config) {
+func overrideSastConfigValue(sastFastScanChanged, sastIncrementalChanged bool, sastConfig *wrappers.SastConfig, config wrappers.Config) {
 	setIfEmpty := func(configValue *string, resubmitValue interface{}) {
 		if *configValue == "" && resubmitValue != nil {
 			*configValue = resubmitValue.(string)
 		}
 	}
-
-	sastFastScanChanged := cmd.Flags().Changed(commonParams.SastFastScanFlag)
-	sastIncrementalChanged := cmd.Flags().Changed(commonParams.IncrementalSast)
 
 	if resubmitIncremental := config.Value[configIncremental]; resubmitIncremental != nil && !sastIncrementalChanged {
 		sastConfig.Incremental = resubmitIncremental.(string)

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -869,7 +869,7 @@ func TestAddSastScan(t *testing.T) {
 	cmdCommand.PersistentFlags().String(commonParams.PresetName, "", "Preset name")
 	cmdCommand.PersistentFlags().String(commonParams.SastFilterFlag, "", "Filter for SAST scan")
 	cmdCommand.PersistentFlags().Bool(commonParams.IncrementalSast, false, "Incremental SAST scan")
-	cmdCommand.PersistentFlags().Bool(commonParams.SastFastScanFlag, true, "Enable SAST Fast Scan")
+	cmdCommand.PersistentFlags().Bool(commonParams.SastFastScanFlag, false, "Enable SAST Fast Scan")
 
 	_ = cmdCommand.Execute()
 
@@ -883,7 +883,7 @@ func TestAddSastScan(t *testing.T) {
 		PresetName:   "test",
 		Filter:       "test",
 		Incremental:  "true",
-		FastScanMode: "true",
+		FastScanMode: "",
 	}
 	sastMapConfig := make(map[string]interface{})
 	sastMapConfig[resultsMapType] = commonParams.SastType

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -1845,6 +1845,12 @@ func TestAddSastScan_ScanFlags(t *testing.T) {
 		},
 	}
 
+	oldActualScanTypes := actualScanTypes
+
+	defer func() {
+		actualScanTypes = oldActualScanTypes
+	}()
+
 	for _, tt := range tests {
 		actualScanTypes = "sast,sca,kics,scs"
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -1846,6 +1846,7 @@ func TestAddSastScan_ScanFlags(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		actualScanTypes = "sast,sca,kics,scs"
 		t.Run(tt.name, func(t *testing.T) {
 			cmdCommand := &cobra.Command{
 				Use:   "scan",

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -1858,10 +1858,10 @@ func TestAddSastScan_ScanFlags(t *testing.T) {
 			_ = cmdCommand.Execute()
 
 			if tt.requiredFastScanSet {
-				_ = cmdCommand.Flags().Set(commonParams.SastFastScanFlag, tt.fastScanFlag)
+				_ = cmdCommand.PersistentFlags().Set(commonParams.SastFastScanFlag, tt.fastScanFlag)
 			}
 			if tt.requiredIncrementalSet {
-				_ = cmdCommand.Flags().Set(commonParams.IncrementalSast, tt.incrementalFlag)
+				_ = cmdCommand.PersistentFlags().Set(commonParams.IncrementalSast, tt.incrementalFlag)
 			}
 
 			result := addSastScan(cmdCommand, resubmitConfig)

--- a/internal/wrappers/export-http.go
+++ b/internal/wrappers/export-http.go
@@ -134,7 +134,7 @@ func (e *ExportHTTPWrapper) GetExportReportStatus(reportID string) (*ExportPolli
 			return &model, nil
 		case http.StatusNotFound:
 			_ = resp.Body.Close()
-			time.Sleep(time.Second)
+			time.Sleep(retryInterval)
 		default:
 			_ = resp.Body.Close()
 			return nil, errors.Errorf("response status code %d", resp.StatusCode)


### PR DESCRIPTION
…on base on user input

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Fix fast scan and incremental scan initialization in SAST configuration.

### References

> https://checkmarx.atlassian.net/browse/AST-80553
> https://checkmarx.atlassian.net/browse/AST-80586
> https://checkmarx.atlassian.net/browse/AST-79107

### Testing

> Added UT for all cases

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used