### PR TITLE
Skip of policy evaluated when the scan not finished(AST-81796)

### DIFF
--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -986,9 +986,14 @@ func runGetResultCommand(
 			return errors.Errorf("%s: CODE: %d, %s", failedGettingScan, errorModel.Code, errorModel.Message)
 		}
 
-		policyResponseModel, err := services.HandlePolicyEvaluation(cmd, policyWrapper, scan, ignorePolicy, agent, waitDelay, policyTimeout)
-		if err != nil {
-			return err
+		var policyResponseModel *wrappers.PolicyResponseModel
+		if !isScanPending(string(scan.Status)) {
+			policyResponseModel, err = services.HandlePolicyEvaluation(cmd, policyWrapper, scan, ignorePolicy, agent, waitDelay, policyTimeout)
+			if err != nil {
+				return err
+			}
+		} else {
+			logger.PrintIfVerbose("Policy violations aren't returned in the pipeline for scans run in async mode.")
 		}
 
 		if sastRedundancy {

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -2135,3 +2135,32 @@ func TestScanCreate_WithContainerFilterFlagsAndResubmitFlag_CreatingScanWithLate
 	assert.Equal(t, createdScanConfig.Value[commands.ConfigContainersImagesFilterKey], "*dev", "Image tag filter should be equal")
 	assert.Equal(t, createdScanConfig.Value[commands.ConfigContainersPackagesFilterKey], "^internal-.*", "Package filter should be equal")
 }
+
+func TestCreateScanWithAsyncFlag_TryShowResults_PolicyNotEvaluated(t *testing.T) {
+	createASTIntegrationTestCommand(t)
+	configuration.LoadConfiguration()
+	args := []string{
+		"scan", "create",
+		flag(params.ProjectName), getProjectNameForScanTests(),
+		flag(params.SourcesFlag), Zip,
+		flag(params.ScanTypes), "sast,iac-security,sca",
+		flag(params.BranchFlag), "main",
+		flag(params.AsyncFlag),
+		flag(params.ScanInfoFormatFlag), printer.FormatJSON,
+	}
+	scanID, _ := executeCreateScan(t, args)
+	assert.Assert(t, scanID != "", "Scan ID should not be empty")
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+
+	_ = executeCmdNilAssertion(
+		t, "Results show generating JSON report with options should pass",
+		"results", "show",
+		flag(params.ScanIDFlag), scanID,
+		flag(params.TargetFormatFlag), printer.FormatSummaryConsole,
+		flag(params.DebugFlag),
+	)
+	log.SetOutput(os.Stderr)
+	assert.Assert(t, strings.Contains(buf.String(), "Policy violations aren't returned in the pipeline for scans run in async mode."), "policy shouldn't evaluate in running scan")
+}


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

When try to getting the policy management step, the user receive a message indicating that the scan is currently running and policy management step is being skipped.

### References

https://checkmarx.atlassian.net/browse/AST-81796

### Testing

Add integration test that try to show results before the scan finished.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used