### PR TITLE
Make writeCredentialsToCache func thread safe (AST-82856)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM checkmarx/bash:5.2.37-r2-cbecd9aeaadc77@sha256:cbecd9aeaadc775906af3b4b0b03e05d5a4e68cb300d7db4579d88129b2eb028
+FROM checkmarx/bash:5.2.37-r2-c5dcfc6a2fbe1c@sha256:c5dcfc6a2fbe1c8f9d11bdf902b5485bb78b4733864a99806749d5e244a6b75e
 USER nonroot
 
 COPY cx /app/bin/cx

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptrace"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	applicationErrors "github.com/checkmarx/ast-cli/internal/constants/errors"
@@ -42,6 +43,10 @@ const (
 	contentTypeHeader       = "Content-Type"
 	formURLContentType      = "application/x-www-form-urlencoded"
 	jsonContentType         = "application/json"
+)
+
+var (
+	credentialsMutex sync.Mutex
 )
 
 type ClientCredentialsInfo struct {
@@ -478,6 +483,9 @@ func getClientCredentialsFromCache(tokenExpirySeconds int) string {
 }
 
 func writeCredentialsToCache(accessToken string) {
+	credentialsMutex.Lock()
+	defer credentialsMutex.Unlock()
+
 	logger.PrintIfVerbose("Storing API access token to cache.")
 	viper.Set(commonParams.AstToken, accessToken)
 	cachedAccessToken = accessToken

--- a/internal/wrappers/client_test.go
+++ b/internal/wrappers/client_test.go
@@ -2,10 +2,17 @@ package wrappers
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
+	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	commonParams "github.com/checkmarx/ast-cli/internal/params"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 type mockReadCloser struct{}
@@ -77,4 +84,32 @@ func TestRetryHTTPRequest_EndWithBadGateway(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+}
+
+func TestConcurrentWriteCredentialsToCache(t *testing.T) {
+	var wg sync.WaitGroup
+
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			writeCredentialsToCache(fmt.Sprintf("testToken_%d", i))
+		}(i)
+	}
+	wg.Wait()
+
+	token := viper.Get(commonParams.AstToken)
+	assert.NotNil(t, token, "Token should not be nil")
+
+	tokenStr, ok := token.(string)
+	assert.True(t, ok, "Token should be a string")
+
+	splitToken := strings.Split(tokenStr, "_")
+	assert.Equal(t, 2, len(splitToken), "Token should split into 2 parts")
+	assert.Equal(t, "testToken", splitToken[0], "Token prefix should be 'testToken'")
+
+	testTokenNumber, err := strconv.Atoi(splitToken[1])
+	assert.NoError(t, err, "The token suffix should be a valid number")
+	assert.True(t, testTokenNumber >= 0 && testTokenNumber < 1000,
+		"The token number should be within the expected range")
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Ensure writeCredentialsToCache is thread-safe, Prevent multiple Goroutines from overwriting the cache inconsistently.

### References

> https://checkmarx.atlassian.net/browse/AST-82856

### Testing

> Add unit test

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used