### PR TITLE
Add --iac-security-preset-id flag support (AST-80207)

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -88,6 +88,7 @@ const (
 	configIncremental                       = "incremental"
 	configFastScan                          = "fastScanMode"
 	configPresetName                        = "presetName"
+	configPresetID                          = "presetId"
 	configEngineVerbose                     = "engineVerbose"
 	configLanguageMode                      = "languageMode"
 	ConfigContainersFilesFilterKey          = "filesFilter"
@@ -553,7 +554,10 @@ func scanCreateSubCommand(
 		false,
 		"Incremental SAST scan should be performed.",
 	)
+
 	createScanCmd.PersistentFlags().String(commonParams.PresetName, "", "The name of the Checkmarx preset to use.")
+	createScanCmd.PersistentFlags().String(commonParams.IacsPresetIDFlag, "", commonParams.IacsPresetIDUsage)
+
 	createScanCmd.PersistentFlags().String(
 		commonParams.ScaResolverFlag,
 		"",
@@ -898,6 +902,7 @@ func addKicsScan(cmd *cobra.Command, resubmitConfig []wrappers.Config) map[strin
 		kicsMapConfig[resultsMapType] = commonParams.KicsType
 		kicsConfig.Filter = deprecatedFlagValue(cmd, commonParams.KicsFilterFlag, commonParams.IacsFilterFlag)
 		kicsConfig.Platforms = deprecatedFlagValue(cmd, commonParams.KicsPlatformsFlag, commonParams.IacsPlatformsFlag)
+		kicsConfig.PresetID, _ = cmd.Flags().GetString(commonParams.IacsPresetIDFlag)
 		for _, config := range resubmitConfig {
 			if config.Type == commonParams.KicsType {
 				resubmitFilter := config.Value[configFilterKey]
@@ -907,6 +912,10 @@ func addKicsScan(cmd *cobra.Command, resubmitConfig []wrappers.Config) map[strin
 				resubmitPlatforms := config.Value[configFilterPlatforms]
 				if resubmitPlatforms != nil && kicsConfig.Platforms == "" {
 					kicsConfig.Platforms = resubmitPlatforms.(string)
+				}
+				resubmitPresetID := config.Value[configPresetID]
+				if resubmitPresetID != nil && kicsConfig.PresetID == "" {
+					kicsConfig.PresetID = resubmitPresetID.(string)
 				}
 			}
 		}
@@ -2789,6 +2798,12 @@ func validateCreateScanFlags(cmd *cobra.Command) error {
 	err = validateBooleanString(projectPrivatePackage)
 	if err != nil {
 		return errors.Errorf("Invalid value for --project-private-package flag. The value must be true or false.")
+	}
+
+	if kicsPresetID, _ := cmd.Flags().GetString(commonParams.IacsPresetIDFlag); kicsPresetID != "" {
+		if _, err := uuid.Parse(kicsPresetID); err != nil {
+			return fmt.Errorf("Invalid value for --%s flag. Must be a valid UUID.", commonParams.IacsPresetIDFlag)
+		}
 	}
 
 	return nil

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -58,6 +58,7 @@ const (
 	additionalParamsError                  = "flag needs an argument: --additional-params"
 	scanCommand                            = "scan"
 	kicsRealtimeCommand                    = "kics-realtime"
+	kicsPresetIDIncorrectValueError        = "Invalid value for --iac-security-preset-id flag. Must be a valid UUID."
 	InvalidEngineMessage                   = "Please verify if engine is installed"
 	SCSScoreCardError                      = "SCS scan failed to start: Scorecard scan is missing required flags, please include in the ast-cli arguments: " +
 		"--scs-repo-url your_repo_url --scs-repo-token your_repo_token"
@@ -512,6 +513,20 @@ func TestScanWorkFlowWithKicsPlatformsDeprecated(t *testing.T) {
 	cmd := createASTTestCommand()
 	err := executeTestCommand(cmd, baseArgs...)
 	assert.NilError(t, err)
+}
+
+func TestScanWorkFlowWithKicsPresetID(t *testing.T) {
+	baseArgs := []string{"scan", "create", "--project-name", "kicsPresetIDMock", "-b", "dummy_branch", "-s", dummyRepo, "--iac-security-preset-id", "4801dea3-b365-4934-a810-ebf481f646c3"}
+	cmd := createASTTestCommand()
+	err := executeTestCommand(cmd, baseArgs...)
+	assert.NilError(t, err)
+}
+
+func TestScanWorkFlowWithInvalidKicsPresetID(t *testing.T) {
+	baseArgs := []string{"scan", "create", "--project-name", "kicsPresetIDMock", "-b", "dummy_branch", "-s", dummyRepo, "--iac-security-preset-id", "invalid uuid"}
+	cmd := createASTTestCommand()
+	err := executeTestCommand(cmd, baseArgs...)
+	assert.Error(t, err, kicsPresetIDIncorrectValueError, err.Error())
 }
 
 func TestScanWorkFlowWithScaFilter(t *testing.T) {

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -139,6 +139,8 @@ const (
 	KicsPlatformsFlagUsage       = "KICS Platform Flag. Use ',' as the delimiter for arrays."
 	IacsPlatformsFlag            = "iac-security-platforms"
 	IacsPlatformsFlagUsage       = "IaC Security Platform Flag"
+	IacsPresetIDFlag             = "iac-security-preset-id"
+	IacsPresetIDUsage            = "The ID of the IaC Security Preset to use (must be a valid UUID)."
 	ApikeyOverrideFlag           = "apikey-override"
 	ExploitablePathFlag          = "sca-exploitable-path"
 	LastSastScanTime             = "sca-last-sast-scan-time"
@@ -285,12 +287,16 @@ var (
 )
 
 // Custom states
-const  IncludeDeletedQueryParam = "include-deleted"
-const True 						= "true"
+const (
+	IncludeDeletedQueryParam = "include-deleted"
+	True                     = "true"
+)
 
 // System States
-const ToVerify               = "TO_VERIFY"
-const NotExploitable          = "NOT_EXPLOITABLE"
-const ProposedNotExploitable = "PROPOSED_NOT_EXPLOITABLE"
-const CONFIRMED               = "CONFIRMED"
-const URGENT                  = "URGENT"
+const (
+	ToVerify               = "TO_VERIFY"
+	NotExploitable         = "NOT_EXPLOITABLE"
+	ProposedNotExploitable = "PROPOSED_NOT_EXPLOITABLE"
+	CONFIRMED              = "CONFIRMED"
+	URGENT                 = "URGENT"
+)

--- a/internal/wrappers/scans.go
+++ b/internal/wrappers/scans.go
@@ -132,6 +132,7 @@ type SastConfig struct {
 type KicsConfig struct {
 	Filter    string `json:"filter,omitempty"`
 	Platforms string `json:"platforms,omitempty"`
+	PresetID  string `json:"presetId,omitempty"`
 }
 
 type ScaConfig struct {


### PR DESCRIPTION
**By submitting this pull request, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please review the [contributing guidelines](../docs/contributing.md) for guidance on creating high-quality pull requests.**

## Description

- Add "--iac-security-preset-id" flag:
  - When creating a KICS scan, allow the user to add a PresetID to be used.
  - Add unit tests to verify that the command is properly built.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable)
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/7908f202-577e-4571-bb59-5a93df9b0959)
![image](https://github.com/user-attachments/assets/a0d09f83-d049-4a78-bb42-ffa8ce7e8abd)