### PR TITLE
Implement retry logic for token-related 5XX responses (AST-95350) , (AST-89866)

### DIFF
--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -110,11 +110,7 @@ func retryHTTPForIAMRequest(requestFunc func() (*http.Response, error), retries 
 		if err != nil {
 			return nil, err
 		}
-		if (resp.StatusCode == http.StatusInternalServerError) ||
-			(resp.StatusCode == http.StatusNotImplemented) ||
-			(resp.StatusCode == http.StatusBadGateway) ||
-			(resp.StatusCode == http.StatusServiceUnavailable) ||
-			(resp.StatusCode == http.StatusGatewayTimeout) {
+		if resp.StatusCode >= 500 && resp.StatusCode <= 504 {
 			logger.PrintIfVerbose(fmt.Sprintf("Encountered HTTP %s response — will retry ", resp.Status))
 		} else if resp.StatusCode == http.StatusInternalServerError {
 			logger.PrintIfVerbose("Unauthorized request (401), refreshing token")

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -113,7 +113,7 @@ func retryHTTPForIAMRequest(requestFunc func() (*http.Response, error), retries 
 		if resp.StatusCode >= 500 && resp.StatusCode <= 504 {
 			logger.PrintIfVerbose(fmt.Sprintf("Encountered HTTP %s response — will retry ", resp.Status))
 		} else if resp.StatusCode == http.StatusUnauthorized {
-			logger.PrintIfVerbose("Unauthorized request (401), refreshing token")
+			logger.PrintIfVerbose("Unauthorized request (401), refreshing token  ")
 			_, _ = configureClientCredentialsAndGetNewToken()
 		} else {
 			return resp, nil

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -112,7 +112,7 @@ func retryHTTPForIAMRequest(requestFunc func() (*http.Response, error), retries 
 		}
 		if resp.StatusCode >= 500 && resp.StatusCode <= 504 {
 			logger.PrintIfVerbose(fmt.Sprintf("Encountered HTTP %s response — will retry ", resp.Status))
-		} else if resp.StatusCode == http.StatusInternalServerError {
+		} else if resp.StatusCode == http.StatusUnauthorized {
 			logger.PrintIfVerbose("Unauthorized request (401), refreshing token")
 			_, _ = configureClientCredentialsAndGetNewToken()
 		} else {

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -121,7 +121,7 @@ func retryHTTPForIAMRequest(requestFunc func() (*http.Response, error), retries 
 		_ = resp.Body.Close()
 		time.Sleep(baseDelayInMilliSec * (1 << attempt))
 	}
-	return resp, nil
+	return nil, err
 }
 
 func setAgentNameAndOrigin(req *http.Request) {

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -99,6 +99,35 @@ func retryHTTPRequest(requestFunc func() (*http.Response, error), retries int, b
 	return resp, nil
 }
 
+// "Check the response status; if it is one of 500, 501, 502, 503, or 504, the request will be resending (only 4 retries)."
+func retryHTTPForIAMRequest(requestFunc func() (*http.Response, error), retries int, baseDelayInMilliSec time.Duration) (*http.Response, error) {
+
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; attempt < retries; attempt++ {
+		resp, err = requestFunc()
+		if err != nil {
+			return nil, err
+		}
+		if (resp.StatusCode == http.StatusInternalServerError) ||
+			(resp.StatusCode == http.StatusNotImplemented) ||
+			(resp.StatusCode == http.StatusBadGateway) ||
+			(resp.StatusCode == http.StatusServiceUnavailable) ||
+			(resp.StatusCode == http.StatusGatewayTimeout) {
+			logger.PrintIfVerbose(fmt.Sprintf("Encountered HTTP %s response — will retry ", resp.Status))
+		} else if resp.StatusCode == http.StatusInternalServerError {
+			logger.PrintIfVerbose("Unauthorized request (401), refreshing token")
+			_, _ = configureClientCredentialsAndGetNewToken()
+		} else {
+			return resp, nil
+		}
+		_ = resp.Body.Close()
+		time.Sleep(baseDelayInMilliSec * (1 << attempt))
+	}
+	return resp, nil
+}
+
 func setAgentNameAndOrigin(req *http.Request) {
 	agentStr := viper.GetString(commonParams.AgentNameKey) + "/" + commonParams.Version
 	req.Header.Set("User-Agent", agentStr)
@@ -513,7 +542,20 @@ func getNewToken(credentialsPayload, authServerURI string) (string, error) {
 	clientTimeout := viper.GetUint(commonParams.ClientTimeoutKey)
 	client := GetClient(clientTimeout)
 
-	res, err := doPrivateRequest(client, req)
+	//Save body for retry logic
+	var body []byte
+	if req.Body != nil {
+		body, err = io.ReadAll(req.Body)
+	}
+	fn := func() (*http.Response, error) {
+		if body != nil {
+			_ = req.Body.Close()
+			req.Body = io.NopCloser(bytes.NewBuffer(body))
+		}
+		return doPrivateRequest(client, req)
+	}
+	res, err := retryHTTPForIAMRequest(fn, retryAttempts, retryDelay*time.Millisecond)
+
 	if err != nil {
 		authURL, _ := GetAuthURI()
 		return "", errors.Errorf("%s %s", checkmarxURLError, authURL)
@@ -528,7 +570,7 @@ func getNewToken(credentialsPayload, authServerURI string) (string, error) {
 		return "", errors.Errorf("%d %s \n", res.StatusCode, invalidCredentialsError)
 	}
 
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ = ioutil.ReadAll(res.Body)
 	if res.StatusCode != http.StatusOK {
 		credentialsErr := ClientCredentialsError{}
 		err = json.Unmarshal(body, &credentialsErr)


### PR DESCRIPTION
## Description

*Implement retry logic for handling 5XX server responses.*

## Type of Change

- [ ] Bug fix AST-95350 ,Upon receiving a timeout response, the system will attempt the request again. 

## Related Issues

*[Link any related issues or tickets.](https://checkmarx.atlassian.net/browse/AST-95350)*
*[Link any related issues or tickets.](https://checkmarx.atlassian.net/browse/AST-89866)*

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
