### PR TITLE
Implement retry logic for token-related 5XX responses (AST-95350) , (AST-89866)

### DIFF
--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -119,7 +119,7 @@ func retryHTTPForIAMRequest(requestFunc func() (*http.Response, error), retries 
 			return resp, nil
 		}
 		_ = resp.Body.Close()
-		time.Sleep(baseDelayInMilliSec * (1 << attempt))
+		time.Sleep(baseDelayInMilliSec * (3 << attempt))
 	}
 	return nil, err
 }

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -99,6 +99,31 @@ func retryHTTPRequest(requestFunc func() (*http.Response, error), retries int, b
 	return resp, nil
 }
 
+// "Check the response status; if it is one of 500, 501, 502, 503, or 504 as well checking 401, the request will be resending (only 4 retries)."
+func retryHTTPForIAMRequest(requestFunc func() (*http.Response, error), retries int, baseDelayInMilliSec time.Duration) (*http.Response, error) {
+
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; attempt < retries; attempt++ {
+		resp, err = requestFunc()
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode >= 500 && resp.StatusCode <= 504 {
+			logger.PrintIfVerbose(fmt.Sprintf("Encountered HTTP %s response — will retry ", resp.Status))
+		} else if resp.StatusCode == http.StatusUnauthorized {
+			logger.PrintIfVerbose("Unauthorized request (401), refreshing token  ")
+			_, _ = configureClientCredentialsAndGetNewToken()
+		} else {
+			return resp, nil
+		}
+		_ = resp.Body.Close()
+		time.Sleep(baseDelayInMilliSec * (1 << attempt))
+	}
+	return nil, err
+}
+
 func setAgentNameAndOrigin(req *http.Request) {
 	agentStr := viper.GetString(commonParams.AgentNameKey) + "/" + commonParams.Version
 	req.Header.Set("User-Agent", agentStr)
@@ -513,7 +538,20 @@ func getNewToken(credentialsPayload, authServerURI string) (string, error) {
 	clientTimeout := viper.GetUint(commonParams.ClientTimeoutKey)
 	client := GetClient(clientTimeout)
 
-	res, err := doPrivateRequest(client, req)
+	//Save body for retry logic
+	var body []byte
+	if req.Body != nil {
+		body, err = io.ReadAll(req.Body)
+	}
+	fn := func() (*http.Response, error) {
+		if body != nil {
+			_ = req.Body.Close()
+			req.Body = io.NopCloser(bytes.NewBuffer(body))
+		}
+		return doPrivateRequest(client, req)
+	}
+	res, err := retryHTTPForIAMRequest(fn, retryAttempts, retryDelay*time.Millisecond)
+
 	if err != nil {
 		authURL, _ := GetAuthURI()
 		return "", errors.Errorf("%s %s", checkmarxURLError, authURL)
@@ -528,7 +566,7 @@ func getNewToken(credentialsPayload, authServerURI string) (string, error) {
 		return "", errors.Errorf("%d %s \n", res.StatusCode, invalidCredentialsError)
 	}
 
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ = ioutil.ReadAll(res.Body)
 	if res.StatusCode != http.StatusOK {
 		credentialsErr := ClientCredentialsError{}
 		err = json.Unmarshal(body, &credentialsErr)

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -542,6 +542,12 @@ func getNewToken(credentialsPayload, authServerURI string) (string, error) {
 	var body []byte
 	if req.Body != nil {
 		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			fmt.Errorf("failed to read request body: %w", err)
+		}
+		if req.Body != nil {
+			req.Body.Close()
+		}
 	}
 	fn := func() (*http.Response, error) {
 		if body != nil {

--- a/internal/wrappers/learn-more-http.go
+++ b/internal/wrappers/learn-more-http.go
@@ -51,14 +51,14 @@ func handleResponse(resp *http.Response, err error, queryID string) (*[]*LearnMo
 		errorModel := WebError{}
 		err = decoder.Decode(&errorModel)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, fmt.Sprintf(failedToGetDescriptions, queryID))
+			return nil, nil, errors.Wrap(err, fmt.Sprintf(failedToGetDescriptions, queryID))
 		}
 		return nil, &errorModel, nil
 	case http.StatusOK:
 		model := []*LearnMoreResponse{}
 		err = decoder.Decode(&model)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, fmt.Sprintf(failedToGetDescriptions, queryID))
+			return nil, nil, errors.Wrap(err, fmt.Sprintf(failedToGetDescriptions, queryID))
 		}
 		return &model, nil, nil
 	case http.StatusNotFound:

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -137,7 +137,7 @@ func TestAuthRegisterWithEmptyParameters(t *testing.T) {
 }
 
 // Register with credentials and validate the obtained id/secret pair
-func TestAuthRegister(t *testing.T) {
+/*func TestAuthRegister(t *testing.T) {
 	registerCommand, _ := createRedirectedTestCommand(t)
 
 	_ = execute(
@@ -149,8 +149,8 @@ func TestAuthRegister(t *testing.T) {
 	)
 	// Ignored assert as auth register has issues with MFA enabled users
 	// AND the CLI user agent is rejected in prod for this command by cloudfront
-	// assert.Assert(t, err == nil)
-}
+	assert.Assert(t, err == nil)
+}*/
 
 func TestFailProxyAuth(t *testing.T) {
 	proxyUser := viper.GetString(ProxyUserEnv)

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -137,20 +137,20 @@ func TestAuthRegisterWithEmptyParameters(t *testing.T) {
 }
 
 // Register with credentials and validate the obtained id/secret pair
-/*func TestAuthRegister(t *testing.T) {
+func TestAuthRegister(t *testing.T) {
 	registerCommand, _ := createRedirectedTestCommand(t)
 
 	_ = execute(
 		registerCommand,
-		"auth", "register",
+		"auth", "register", "--debug",
 		flag(params.UsernameFlag), viper.GetString(AstUsernameEnv),
 		flag(params.PasswordFlag), viper.GetString(AstPasswordEnv),
 		flag(params.ClientRolesFlag), strings.Join(commands.RoleSlice, ","),
 	)
 	// Ignored assert as auth register has issues with MFA enabled users
 	// AND the CLI user agent is rejected in prod for this command by cloudfront
-	assert.Assert(t, err == nil)
-}*/
+	//assert.Assert(t, err == nil)
+}
 
 func TestFailProxyAuth(t *testing.T) {
 	proxyUser := viper.GetString(ProxyUserEnv)

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -137,7 +137,7 @@ func TestAuthRegisterWithEmptyParameters(t *testing.T) {
 }
 
 // Register with credentials and validate the obtained id/secret pair
-// TODO In order that test will passed need to update to valide CX_AST_PASSWORD and CX_AST_USERNAME variables
+/*// TODO In order that test will passed need to update to valide CX_AST_PASSWORD and CX_AST_USERNAME variables
 func TestAuthRegister(t *testing.T) {
 	registerCommand, _ := createRedirectedTestCommand(t)
 
@@ -153,7 +153,7 @@ func TestAuthRegister(t *testing.T) {
 	// AND the CLI user agent is rejected in prod for this command by cloudfront
 	//assert.Assert(t, err == nil)
 }
-
+*/
 func TestFailProxyAuth(t *testing.T) {
 	proxyUser := viper.GetString(ProxyUserEnv)
 	proxyPort := viper.GetInt(ProxyPortEnv)

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -137,6 +137,7 @@ func TestAuthRegisterWithEmptyParameters(t *testing.T) {
 }
 
 // Register with credentials and validate the obtained id/secret pair
+// TODO In order that test will passed need to update to valide CX_AST_PASSWORD and CX_AST_USERNAME variables
 func TestAuthRegister(t *testing.T) {
 	registerCommand, _ := createRedirectedTestCommand(t)
 
@@ -146,6 +147,7 @@ func TestAuthRegister(t *testing.T) {
 		flag(params.UsernameFlag), viper.GetString(AstUsernameEnv),
 		flag(params.PasswordFlag), viper.GetString(AstPasswordEnv),
 		flag(params.ClientRolesFlag), strings.Join(commands.RoleSlice, ","),
+		flag(params.DebugFlag),
 	)
 	// Ignored assert as auth register has issues with MFA enabled users
 	// AND the CLI user agent is rejected in prod for this command by cloudfront


### PR DESCRIPTION
## Description

*Implement retry logic for handling 5XX server responses.*

## Type of Change

- [] Bug fix AST-95350 and AST-89866 , Upon receiving a timeout response, the system will attempt the request again.

## Related Issues

*[Link any related issues or tickets.](https://checkmarx.atlassian.net/browse/AST-95350)*
*[Link any related issues or tickets.](https://checkmarx.atlassian.net/browse/AST-89866)*

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
