### PR TITLE
Hide --ignore-policy flag (AST-96336)

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -650,6 +650,7 @@ func scanCreateSubCommand(
 		"Cancel the policy evaluation and fail after the timeout in minutes",
 	)
 	createScanCmd.PersistentFlags().Bool(commonParams.IgnorePolicyFlag, false, "Do not evaluate policies")
+	createScanCmd.PersistentFlags().MarkHidden(commonParams.IgnorePolicyFlag)
 
 	createScanCmd.PersistentFlags().String(commonParams.ApplicationName, "", "Name of the application to assign with the project")
 	// Link the environment variables to the CLI argument(s).


### PR DESCRIPTION
Added code changes for hide “--ignore-policy“ flag in “cx scan create -h” or “cx scan create --help“ command.