### PR TITLE
Implement retry logic for token-related 5XX responses (AST-95350) , (AST-89866)

### DIFF
--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -99,6 +99,31 @@ func retryHTTPRequest(requestFunc func() (*http.Response, error), retries int, b
 	return resp, nil
 }
 
+// "Check the response status; if it is one of 500, 501, 502, 503, or 504 as well checking 401, the request will be resending (only 4 retries)."
+func retryHTTPForIAMRequest(requestFunc func() (*http.Response, error), retries int, baseDelayInMilliSec time.Duration) (*http.Response, error) {
+
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; attempt < retries; attempt++ {
+		resp, err = requestFunc()
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode >= 500 && resp.StatusCode <= 504 {
+			logger.PrintIfVerbose(fmt.Sprintf("Encountered HTTP %s response — will retry ", resp.Status))
+		} else if resp.StatusCode == http.StatusUnauthorized {
+			logger.PrintIfVerbose("Unauthorized request (401), refreshing token  ")
+			_, _ = configureClientCredentialsAndGetNewToken()
+		} else {
+			return resp, nil
+		}
+		_ = resp.Body.Close()
+		time.Sleep(baseDelayInMilliSec * (3 << attempt))
+	}
+	return nil, err
+}
+
 func setAgentNameAndOrigin(req *http.Request) {
 	agentStr := viper.GetString(commonParams.AgentNameKey) + "/" + commonParams.Version
 	req.Header.Set("User-Agent", agentStr)
@@ -513,7 +538,26 @@ func getNewToken(credentialsPayload, authServerURI string) (string, error) {
 	clientTimeout := viper.GetUint(commonParams.ClientTimeoutKey)
 	client := GetClient(clientTimeout)
 
-	res, err := doPrivateRequest(client, req)
+	//Save body for retry logic
+	var body []byte
+	if req.Body != nil {
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			fmt.Errorf("failed to read request body: %w", err)
+		}
+		if req.Body != nil {
+			req.Body.Close()
+		}
+	}
+	fn := func() (*http.Response, error) {
+		if body != nil {
+			_ = req.Body.Close()
+			req.Body = io.NopCloser(bytes.NewBuffer(body))
+		}
+		return doPrivateRequest(client, req)
+	}
+	res, err := retryHTTPForIAMRequest(fn, retryAttempts, retryDelay*time.Millisecond)
+
 	if err != nil {
 		authURL, _ := GetAuthURI()
 		return "", errors.Errorf("%s %s", checkmarxURLError, authURL)
@@ -528,7 +572,7 @@ func getNewToken(credentialsPayload, authServerURI string) (string, error) {
 		return "", errors.Errorf("%d %s \n", res.StatusCode, invalidCredentialsError)
 	}
 
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ = ioutil.ReadAll(res.Body)
 	if res.StatusCode != http.StatusOK {
 		credentialsErr := ClientCredentialsError{}
 		err = json.Unmarshal(body, &credentialsErr)


### PR DESCRIPTION
## Description

*Implement retry logic for handling 5XX server responses.*

## Type of Change

- [ ]  Fix bugs AST-95350 and AST-89866 , Upon receiving a timeout response, the system will attempt the request again.
 
## Related Issues

*[AST-95350](https://checkmarx.atlassian.net/browse/AST-95350)*
*[AST-89866](https://checkmarx.atlassian.net/browse/AST-89866)*

## Checklist

- [ ] I have performed a self-review of my code
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [ ]  All active GitHub checks for tests, formatting, and security are passing
- [ ]  The correct base branch is being used


[AST-95350]: https://checkmarx.atlassian.net/browse/AST-95350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AST-89866]: https://checkmarx.atlassian.net/browse/AST-89866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ