### PR TITLE
Fix SCS error message when no Scorecard flags are set (AST-93338)

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1106,7 +1106,7 @@ func isURLSupportedByScorecard(scsRepoURL string) bool {
 	return isGithubURL
 }
 
-func isScorecardRunnable(isScsEnginesFlagSet bool, scsScorecardSelected bool, scsRepoToken string, scsRepoURL string, userScanTypes string) (bool, error) {
+func isScorecardRunnable(isScsEnginesFlagSet, scsScorecardSelected bool, scsRepoToken, scsRepoURL, userScanTypes string) (bool, error) {
 
 	if scsRepoToken == "" || scsRepoURL == "" {
 

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1057,6 +1057,7 @@ func addAPISecScan(cmd *cobra.Command) map[string]interface{} {
 	}
 	return nil
 }
+
 func createResubmitConfig(resubmitConfig []wrappers.Config, scsRepoToken, scsRepoURL string, hasEnterpriseSecretsLicense bool) wrappers.SCSConfig {
 	scsConfig := wrappers.SCSConfig{}
 	for _, config := range resubmitConfig {
@@ -1080,6 +1081,7 @@ func getSCSEnginesSelected(scsEngines string) (isScorecardSelected, isSecretDete
 	if scsEngines == "" {
 		return true, true
 	}
+
 	scsEnginesTypes := strings.Split(scsEngines, ",")
 	for _, engineType := range scsEnginesTypes {
 		engineType = strings.TrimSpace(engineType)
@@ -1090,6 +1092,7 @@ func getSCSEnginesSelected(scsEngines string) (isScorecardSelected, isSecretDete
 			isScorecardSelected = true
 		}
 	}
+
 	return isScorecardSelected, isSecretDetectionSelected
 }
 
@@ -1103,11 +1106,16 @@ func isURLSupportedByScorecard(scsRepoURL string) bool {
 	return isGithubURL
 }
 
-func isScorecardRunnable(scsRepoToken, scsRepoURL, userScanTypes string) (bool, error) {
+func isScorecardRunnable(isScsEnginesFlagSet bool, scsScorecardSelected bool, scsRepoToken string, scsRepoURL string, userScanTypes string) (bool, error) {
+
 	if scsRepoToken == "" || scsRepoURL == "" {
-		if userScanTypes != "" {
+
+		// with --scs-engine "scorecard" set, if flags not defined, scorecard will launch an error
+		if userScanTypes != "" && isScsEnginesFlagSet && scsScorecardSelected {
 			return false, errors.New(ScsRepoRequiredMsg)
 		}
+
+		// with no --scan-types flag or --scan-types "scs", if flags not defined, scorecard will launch a warning, otherwise will run
 		fmt.Println(ScsRepoWarningMsg)
 		return false, nil
 	}
@@ -1120,33 +1128,42 @@ func addSCSScan(cmd *cobra.Command, resubmitConfig []wrappers.Config, hasEnterpr
 		return nil, nil
 	}
 	scsConfig := wrappers.SCSConfig{}
-	SCSMapConfig := make(map[string]interface{})
-	SCSMapConfig[resultsMapType] = commonParams.MicroEnginesType // scs is still microengines in the scans API
+	scsMapConfig := make(map[string]interface{})
+
+	scsMapConfig[resultsMapType] = commonParams.MicroEnginesType // scs is still microengines in the scans API
 	userScanTypes, _ := cmd.Flags().GetString(commonParams.ScanTypes)
+
 	scsRepoToken := viper.GetString(commonParams.ScsRepoTokenKey)
 	if token, _ := cmd.Flags().GetString(commonParams.SCSRepoTokenFlag); token != "" {
 		scsRepoToken = token
 	}
-	viper.Set(commonParams.SCSRepoTokenFlag, scsRepoToken) // sanitizeLogs uses viper to get the value
+
+	viper.Set(commonParams.SCSRepoTokenFlag, scsRepoToken)
 	scsRepoURL, _ := cmd.Flags().GetString(commonParams.SCSRepoURLFlag)
-	viper.Set(commonParams.SCSRepoURLFlag, scsRepoURL) // sanitizeLogs uses viper to get the value
-	SCSEngines, _ := cmd.Flags().GetString(commonParams.SCSEnginesFlag)
+
+	viper.Set(commonParams.SCSRepoURLFlag, scsRepoURL)
+	scsEngines, _ := cmd.Flags().GetString(commonParams.SCSEnginesFlag)
+
 	if resubmitConfig != nil {
 		scsConfig = createResubmitConfig(resubmitConfig, scsRepoToken, scsRepoURL, hasEnterpriseSecretsLicense)
-		SCSMapConfig[resultsMapValue] = &scsConfig
-		return SCSMapConfig, nil
+		scsMapConfig[resultsMapValue] = &scsConfig
+		return scsMapConfig, nil
 	}
-	scsScoreCardSelected, scsSecretDetectionSelected := getSCSEnginesSelected(SCSEngines)
+
+	scsScoreCardSelected, scsSecretDetectionSelected := getSCSEnginesSelected(scsEngines) // secret-detection or scorecard
 
 	if scsSecretDetectionSelected && hasEnterpriseSecretsLicense {
 		scsConfig.Twoms = trueString
 	}
 
+	isScsEnginesFlagSet := scsEngines != ""
+
 	if scsScoreCardSelected {
-		canRunScorecard, err := isScorecardRunnable(scsRepoToken, scsRepoURL, userScanTypes)
+		canRunScorecard, err := isScorecardRunnable(isScsEnginesFlagSet, scsScoreCardSelected, scsRepoToken, scsRepoURL, userScanTypes)
 		if err != nil {
 			return nil, err
 		}
+
 		if canRunScorecard {
 			scsConfig.Scorecard = trueString
 			scsConfig.RepoToken = scsRepoToken
@@ -1158,8 +1175,8 @@ func addSCSScan(cmd *cobra.Command, resubmitConfig []wrappers.Config, hasEnterpr
 		return nil, nil
 	}
 
-	SCSMapConfig[resultsMapValue] = &scsConfig
-	return SCSMapConfig, nil
+	scsMapConfig[resultsMapValue] = &scsConfig
+	return scsMapConfig, nil
 }
 
 func validateScanTypes(cmd *cobra.Command, jwtWrapper wrappers.JWTWrapper, featureFlagsWrapper wrappers.FeatureFlagsWrapper) error {


### PR DESCRIPTION
**By submitting this pull request, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please review the [contributing guidelines](../docs/contributing.md) for guidance on creating high-quality pull requests.**

## Description

Handling bug where in the scenario of passing --scan-types "scs" and not specifying scorecard specific flags such as token and repo, an error would be triggered, blocking further execution. The correct behavior is that scorecard should be skipped and a warning should be displayed while secret-detection should run. This PR addresses this by only giving error if scorecard is specifically stated to run with --scs-engine flag set to scorecard.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

[AST-93338](https://checkmarx.atlassian.net/browse/AST-93338)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable)
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used

## Screenshots (if applicable)

Now:
![image](https://github.com/user-attachments/assets/1fabda26-6626-4170-b1bc-42b057809e56)

Previously:
![image](https://github.com/user-attachments/assets/031cada4-fe6a-4e95-a298-dfdd98f028e2)


## Additional Notes



*Add any other relevant information.*


[AST-93338]: https://checkmarx.atlassian.net/browse/AST-93338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ