### PR TITLE
Scan Create command: Fix for Source zip with ScaResolver issue (AST-73409)

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -1593,12 +1593,17 @@ func getUploadURLFromSource(cmd *cobra.Command, uploadsWrapper wrappers.UploadsW
 	sourceDirFilter, _ := cmd.Flags().GetString(commonParams.SourceDirFilterFlag)
 	userIncludeFilter, _ := cmd.Flags().GetString(commonParams.IncludeFilterFlag)
 	projectName, _ := cmd.Flags().GetString(commonParams.ProjectName)
+	scaResolverPath, _ := cmd.Flags().GetString(commonParams.ScaResolverFlag)
 	containerEngineCLIEnabled, _ := wrappers.GetSpecificFeatureFlag(featureFlagsWrapper, wrappers.ContainerEngineCLIEnabled)
 
 	containerScanTriggered := strings.Contains(actualScanTypes, commonParams.ContainersType) && containerEngineCLIEnabled.Status
 	scaResolverParams, scaResolver := getScaResolverFlags(cmd)
 
 	zipFilePath, directoryPath, err := definePathForZipFileOrDirectory(cmd)
+
+	if zipFilePath != "" && scaResolverPath != "" {
+		return "", "", errors.New("Scanning Zip files is not supported by ScaResolver.Please use non-zip source")
+	}
 	if err != nil {
 		return "", "", errors.Wrapf(err, "%s: Input in bad format", failedCreating)
 	}

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -2236,5 +2236,4 @@ func TestCreateScanWith_ScaResolver_Source_as_Zip(t *testing.T) {
 	}
 	err := execCmdNotNilAssertion(t, baseArgs...)
 	assert.Assert(t, strings.Contains(err.Error(), ScaResolverZipNotSupportedErr), err.Error())
-
 }

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -62,8 +62,9 @@ const (
 	InvalidEngineMessage                   = "Please verify if engine is installed"
 	SCSScoreCardError                      = "SCS scan failed to start: Scorecard scan is missing required flags, please include in the ast-cli arguments: " +
 		"--scs-repo-url your_repo_url --scs-repo-token your_repo_token"
-	outputFileName              = "test_output.log"
-	noUpdatesForExistingProject = "No tags to update. Skipping project update."
+	outputFileName                = "test_output.log"
+	noUpdatesForExistingProject   = "No tags to update. Skipping project update."
+	ScaResolverZipNotSupportedErr = "Scanning Zip files is not supported by ScaResolver.Please use non-zip source"
 )
 
 func TestScanHelp(t *testing.T) {
@@ -2217,4 +2218,23 @@ func TestIsContainersEngineEnabled_FlagRetrievalFails(t *testing.T) {
 	result := isContainersEngineEnabled(mock.FeatureFlagsMockWrapper{})
 
 	assert.Assert(t, !result, "expected result to be false")
+}
+
+func TestCreateScanWith_ScaResolver_Source_as_Zip(t *testing.T) {
+	clearFlags()
+	baseArgs := []string{
+		"scan",
+		"create",
+		"--project-name",
+		"MOCK",
+		"-s",
+		"data/sources.zip",
+		"-b",
+		"dummy_branch",
+		"--sca-resolver",
+		"ScaResolver.exe",
+	}
+	err := execCmdNotNilAssertion(t, baseArgs...)
+	assert.Assert(t, strings.Contains(err.Error(), ScaResolverZipNotSupportedErr), err.Error())
+
 }

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -2351,3 +2351,18 @@ func deletePreset(engine, presetID string) error {
 
 	return nil
 }
+
+func TestCreateScan_WithScaResolver_ZipSource_Fail(t *testing.T) {
+	configuration.LoadConfiguration()
+	args := []string{
+		"scan", "create",
+		flag(params.ProjectName), getProjectNameForScanTests(),
+		flag(params.SourcesFlag), "data/insecure.zip",
+		flag(params.ScanTypes), params.ScaType,
+		flag(params.BranchFlag), "dummy_branch",
+		flag(params.ScaResolverFlag), "ScaResolver.exe",
+	}
+
+	err, _ := executeCommand(t, args...)
+	assert.Error(t, err, "Scanning Zip files is not supported by ScaResolver.Please use non-zip source")
+}


### PR DESCRIPTION
**By submitting this pull request, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please review the [contributing guidelines](../docs/contributing.md) for guidance on creating high-quality pull requests.**

## Description

*Display Scaresolver error message when the required fields are not valid.*

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used

## Screenshots (if applicable)

**Issue/Bug**
If customer has passed ScaResolver path --sca-resolver  with Source as Zip, the Scan used to get triggered from CxOne SCA scan and not using offline SCA Resolver. Offline Sca-Resolver does not support the zip source

**Fix Added** : 
When Scan create is triggered with source  as zip and scaResolver path is set 

**Error is displayed as : Scanning Zip files is not supported by ScaResolver. Please use non-zip source**

![image](https://github.com/user-attachments/assets/b0a46430-d7c7-4d0a-9321-919f6b11c1f4)

