### PR TITLE
Removed feature flag new-sast-scan-result-enabled(AST-99956)

### DIFF
--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -1787,7 +1787,7 @@ func exportJSONResults(targetFile string, results *wrappers.ScanResultsCollectio
 func exportJSONReportResults(jsonWrapper wrappers.ResultsJSONWrapper, summary *wrappers.ResultSummary, summaryRpt string, featureFlagsWrapper wrappers.FeatureFlagsWrapper) error {
 	jsonReportsPayload := &wrappers.JSONReportsPayload{}
 	pollingResp := &wrappers.JSONPollingResponse{}
-	jsonReportsPayload.ReportName = reportNameScanReport
+	jsonReportsPayload.ReportName = reportNameImprovedScanReport
 
 	jsonOptionsSections, jsonOptionsEngines := parseJSONOptions(summary.EnginesEnabled, jsonReportsPayload.ReportName)
 
@@ -1885,7 +1885,7 @@ func exportPdfResults(pdfWrapper wrappers.ResultsPdfWrapper, summary *wrappers.R
 	pdfOptions string, featureFlagsWrapper wrappers.FeatureFlagsWrapper) error {
 	pdfReportsPayload := &wrappers.PdfReportsPayload{}
 	pollingResp := &wrappers.PdfPollingResponse{}
-	pdfReportsPayload.ReportName = reportNameScanReport
+	pdfReportsPayload.ReportName = reportNameImprovedScanReport
 	pdfOptionsSections, pdfOptionsEngines, err := parsePDFOptions(pdfOptions, summary.EnginesEnabled, pdfReportsPayload.ReportName)
 	if err != nil {
 		return err

--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -1787,13 +1787,7 @@ func exportJSONResults(targetFile string, results *wrappers.ScanResultsCollectio
 func exportJSONReportResults(jsonWrapper wrappers.ResultsJSONWrapper, summary *wrappers.ResultSummary, summaryRpt string, featureFlagsWrapper wrappers.FeatureFlagsWrapper) error {
 	jsonReportsPayload := &wrappers.JSONReportsPayload{}
 	pollingResp := &wrappers.JSONPollingResponse{}
-	flagResponse, _ := wrappers.GetSpecificFeatureFlag(featureFlagsWrapper, wrappers.NewScanReportEnabled)
-	newScanReportEnabled := flagResponse.Status
-	if newScanReportEnabled {
-		jsonReportsPayload.ReportName = reportNameImprovedScanReport
-	} else {
-		jsonReportsPayload.ReportName = reportNameScanReport
-	}
+	jsonReportsPayload.ReportName = reportNameScanReport
 
 	jsonOptionsSections, jsonOptionsEngines := parseJSONOptions(summary.EnginesEnabled, jsonReportsPayload.ReportName)
 
@@ -1891,19 +1885,11 @@ func exportPdfResults(pdfWrapper wrappers.ResultsPdfWrapper, summary *wrappers.R
 	pdfOptions string, featureFlagsWrapper wrappers.FeatureFlagsWrapper) error {
 	pdfReportsPayload := &wrappers.PdfReportsPayload{}
 	pollingResp := &wrappers.PdfPollingResponse{}
-	flagResponse, _ := wrappers.GetSpecificFeatureFlag(featureFlagsWrapper, wrappers.NewScanReportEnabled)
-	newScanReportEnabled := flagResponse.Status
-	if newScanReportEnabled {
-		pdfReportsPayload.ReportName = reportNameImprovedScanReport
-	} else {
-		pdfReportsPayload.ReportName = reportNameScanReport
-	}
-
+	pdfReportsPayload.ReportName = reportNameScanReport
 	pdfOptionsSections, pdfOptionsEngines, err := parsePDFOptions(pdfOptions, summary.EnginesEnabled, pdfReportsPayload.ReportName)
 	if err != nil {
 		return err
 	}
-
 	pdfReportsPayload.ReportType = CliType
 	pdfReportsPayload.FileFormat = printer.FormatPDF
 	pdfReportsPayload.Data.ScanID = summary.ScanID

--- a/internal/commands/result_test.go
+++ b/internal/commands/result_test.go
@@ -643,7 +643,6 @@ func TestRunGetBFLByScanIdAndQueryIdWithFormatList(t *testing.T) {
 
 func TestRunGetResultsGeneratingPdfReportWithInvalidEmail(t *testing.T) {
 	clearFlags()
-	mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.NewScanReportEnabled, Status: false}
 	err := execCmdNotNilAssertion(t,
 		"results", "show",
 		"--report-format", "pdf",
@@ -689,7 +688,6 @@ func TestRunGetResultsGeneratingPdfReportWithEmailAndOptions(t *testing.T) {
 
 func TestRunGetResultsGeneratingPdfReportWithOptionsImprovedMappingHappens(t *testing.T) {
 	clearFlags()
-	mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.NewScanReportEnabled, Status: true}
 	cmd := createASTTestCommand()
 	err := executeTestCommand(cmd,
 		"results", "show",
@@ -702,7 +700,6 @@ func TestRunGetResultsGeneratingPdfReportWithOptionsImprovedMappingHappens(t *te
 
 func TestRunGetResultsGeneratingPdfReportWithInvalidOptionsImproved(t *testing.T) {
 	clearFlags()
-	mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.NewScanReportEnabled, Status: true}
 	cmd := createASTTestCommand()
 	err := executeTestCommand(cmd,
 		"results", "show",
@@ -715,7 +712,6 @@ func TestRunGetResultsGeneratingPdfReportWithInvalidOptionsImproved(t *testing.T
 
 func TestRunGetResultsGeneratingPdfReportWithOptions(t *testing.T) {
 	clearFlags()
-	mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.NewScanReportEnabled, Status: false}
 	cmd := createASTTestCommand()
 	err := executeTestCommand(cmd,
 		"results", "show",
@@ -734,7 +730,6 @@ func TestRunGetResultsGeneratingPdfReportWithOptions(t *testing.T) {
 
 func TestRunGetResultsGeneratingJsonV2Report(t *testing.T) {
 	clearFlags()
-	mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.NewScanReportEnabled, Status: false}
 	cmd := createASTTestCommand()
 	err := executeTestCommand(cmd,
 		"results", "show",

--- a/internal/commands/result_test.go
+++ b/internal/commands/result_test.go
@@ -653,7 +653,6 @@ func TestRunGetResultsGeneratingPdfReportWithInvalidEmail(t *testing.T) {
 
 func TestRunGetResultsGeneratingPdfReportWithInvalidOptions(t *testing.T) {
 	clearFlags()
-	mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.NewScanReportEnabled, Status: false}
 	err := execCmdNotNilAssertion(t,
 		"results", "show",
 		"--report-format", "pdf",
@@ -664,7 +663,6 @@ func TestRunGetResultsGeneratingPdfReportWithInvalidOptions(t *testing.T) {
 
 func TestRunGetResultsGeneratingPdfReportWithInvalidImprovedOptions(t *testing.T) {
 	clearFlags()
-	mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.NewScanReportEnabled, Status: false}
 	err := execCmdNotNilAssertion(t,
 		"results", "show",
 		"--report-format", "pdf",
@@ -675,7 +673,6 @@ func TestRunGetResultsGeneratingPdfReportWithInvalidImprovedOptions(t *testing.T
 
 func TestRunGetResultsGeneratingPdfReportWithEmailAndOptions(t *testing.T) {
 	clearFlags()
-	mock.Flag = wrappers.FeatureFlagResponseModel{Name: wrappers.NewScanReportEnabled, Status: false}
 	cmd := createASTTestCommand()
 	err := executeTestCommand(cmd,
 		"results", "show",

--- a/internal/wrappers/feature-flags.go
+++ b/internal/wrappers/feature-flags.go
@@ -57,15 +57,6 @@ var FeatureFlagsBaseMap = []CommandFlags{
 		},
 	},
 	{
-		CommandName: "cx results show",
-		FeatureFlags: []FlagBase{
-			{
-				Name:    NewScanReportEnabled,
-				Default: false,
-			},
-		},
-	},
-	{
 		CommandName: "cx triage update",
 		FeatureFlags: []FlagBase{
 			{

--- a/internal/wrappers/feature-flags.go
+++ b/internal/wrappers/feature-flags.go
@@ -14,7 +14,6 @@ const MinioEnabled = "MINIO_ENABLED"
 const SastCustomStateEnabled = "SAST_CUSTOM_STATES_ENABLED"
 const ContainerEngineCLIEnabled = "CONTAINER_ENGINE_CLI_ENABLED"
 const SCSEngineCLIEnabled = "NEW_2MS_SCORECARD_RESULTS_CLI_ENABLED"
-const NewScanReportEnabled = "NEW_SAST_SCAN_REPORT_ENABLED"
 const RiskManagementEnabled = "RISK_MANAGEMENT_IDES_PROJECT_RESULTS_SCORES_API_ENABLED"
 const OssRealtimeEnabled = "OSS_REALTIME_ENABLED"
 const maxRetries = 3


### PR DESCRIPTION
**By submitting this pull request, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please review the [contributing guidelines](../docs/contributing.md) for guidance on creating high-quality pull requests.**

## Description

*Removing the FF NEW-SAST-SCAN-RESULT-ENABLED as its enabled for all the customers in production. *
Removing the logic when flag is off


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## Related Issues

*Link any related issues or tickets.*

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable)
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used

## Screenshots (if applicable)

*Add screenshots to help explain your changes.*

## Additional Notes

*Add any other relevant information.*
