### PR TITLE
Fix Sca Vulnerability urllib3 ,Change from 1.26.30 to 2.5.0 (AST-0000)

### DIFF
--- a/internal/commands/data/manifests/requirements.txt
+++ b/internal/commands/data/manifests/requirements.txt
@@ -59,7 +59,7 @@ Django>=3.0,<4.0
 
 # Less than or equal
 
-requests<=2.25.1
+requests<=2.32.4
 
 # Compatible release (PEP 440)
 

--- a/internal/commands/data/manifests/requirements.txt
+++ b/internal/commands/data/manifests/requirements.txt
@@ -63,7 +63,7 @@ requests<=2.25.1
 
 # Compatible release (PEP 440)
 
-urllib3\~=1.26.0
+urllib3\~=2.5.0
 
 # Not equal
 

--- a/test/integration/data/manifests/requirements.txt
+++ b/test/integration/data/manifests/requirements.txt
@@ -59,7 +59,7 @@ Django>=3.0,<4.0
 
 # Less than or equal
 
-requests<=2.25.1
+requests<=2.32.4
 
 # Compatible release (PEP 440)
 

--- a/test/integration/data/manifests/requirements.txt
+++ b/test/integration/data/manifests/requirements.txt
@@ -63,7 +63,7 @@ requests<=2.25.1
 
 # Compatible release (PEP 440)
 
-urllib3\~=1.26.0
+urllib3\~=2.5.0
 
 # Not equal
 


### PR DESCRIPTION
## Description

*Fix Sca Vulnerability urllib3 ,Change from 1.26.30 to 2.5.0*
