### PR TITLE
Custom log output flag(AST-84992)

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -105,7 +105,7 @@ func NewAstCLI(
 
 	_ = rootCmd.PersistentFlags().MarkHidden(params.ApikeyOverrideFlag)
 	rootCmd.PersistentFlags().String(params.LogFileFlag, "", params.LogFileUsage)
-	rootCmd.PersistentFlags().String(params.LogFileStdoutFlag, "", params.LogFileStdOutUsage)
+	rootCmd.PersistentFlags().String(params.LogFileConsoleFlag, "", params.LogFileConsoleUsage)
 
 	// This monitors and traps situations where "extra/garbage" commands
 	// are passed to Cobra.
@@ -148,7 +148,7 @@ func NewAstCLI(
 	_ = viper.BindPFlag(params.RetryDelayFlag, rootCmd.PersistentFlags().Lookup(params.RetryDelayFlag))
 	_ = viper.BindPFlag(params.ApikeyOverrideFlag, rootCmd.PersistentFlags().Lookup(params.ApikeyOverrideFlag))
 	_ = viper.BindPFlag(params.LogFileFlag, rootCmd.PersistentFlags().Lookup(params.LogFileFlag))
-	_ = viper.BindPFlag(params.LogFileStdoutFlag, rootCmd.PersistentFlags().Lookup(params.LogFileStdoutFlag))
+	_ = viper.BindPFlag(params.LogFileConsoleFlag, rootCmd.PersistentFlags().Lookup(params.LogFileConsoleFlag))
 	// Set help func
 	rootCmd.SetHelpFunc(
 		func(command *cobra.Command, args []string) {
@@ -353,8 +353,8 @@ func customLogConfiguration(cmd *cobra.Command) error {
 			return err
 		}
 	}
-	if cmd.PersistentFlags().Changed(params.LogFileStdoutFlag) {
-		if err := setLogOutputFromFlag(params.LogFileStdoutFlag, viper.GetString(params.LogFileStdoutFlag)); err != nil {
+	if cmd.PersistentFlags().Changed(params.LogFileConsoleFlag) {
+		if err := setLogOutputFromFlag(params.LogFileConsoleFlag, viper.GetString(params.LogFileConsoleFlag)); err != nil {
 			return err
 		}
 	}
@@ -392,7 +392,7 @@ func setLogOutputFromFlag(flag string, dirPath string) error {
 	// If the flag indicates stdout logging is enabled, log output is duplicated to both file and console.
 	// Otherwise, logs are written only to the file.
 	var multiWriter io.Writer
-	if flag == params.LogFileStdoutFlag {
+	if flag == params.LogFileConsoleFlag {
 		multiWriter = io.MultiWriter(file, os.Stdout)
 	} else {
 		multiWriter = io.MultiWriter(file)

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -369,7 +369,7 @@ func setLogOutputFromFlag(flag string, dirPath string) error {
 	// Confirm it’s a directory
 	info, err := os.Stat(dirPath)
 	if err != nil {
-		return fmt.Errorf("unable to stat path %s: %v", dirPath, err)
+		return fmt.Errorf("cannot access or retrieve status for path %q: %v", dirPath, err)
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("expected a directory path but got a file: %s", dirPath)

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -386,7 +386,7 @@ func processLogFlag(cmd *cobra.Command, flag string) error {
 			defer file.Close()
 			fileInfo, _ = os.Stat(logFilePath) // Refresh file info after creation
 		} else {
-			return fmt.Errorf("Unexpected error checking file path: %v", err)
+			return fmt.Errorf("Invalid file path: %v", err)
 		}
 	}
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -369,10 +369,13 @@ func setLogOutputFromFlag(flag string, dirPath string) error {
 	// Confirm it’s a directory
 	info, err := os.Stat(dirPath)
 	if err != nil {
-		return fmt.Errorf("cannot access or retrieve status for path %q: %v", dirPath, err)
+		if os.IsNotExist(err) {
+			return fmt.Errorf("The specified directory path does not exist. Please check the path.")
+		}
+		return fmt.Errorf("An error occurred while accessing the directory path. Please check the path.")
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("expected a directory path but got a file: %s", dirPath)
+		return fmt.Errorf("Expected a directory path but got a file: %s", dirPath)
 	}
 
 	// Create full path for the log file
@@ -383,9 +386,9 @@ func setLogOutputFromFlag(flag string, dirPath string) error {
 	file, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		if os.IsPermission(err) {
-			return fmt.Errorf("permission denied: cannot write to directory %s", dirPath)
+			return fmt.Errorf("Permission denied: cannot write to directory %s", dirPath)
 		}
-		return fmt.Errorf("unable to open log file %s: %v", logFilePath, err)
+		return fmt.Errorf("Unable to open log file %s: %v", logFilePath, err)
 	}
 
 	// Configure the logger to write to the log file and optionally to stdout.

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -370,9 +370,9 @@ func setLogOutputFromFlag(flag string, dirPath string) error {
 	info, err := os.Stat(dirPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("The specified directory path does not exist. Please check the path.")
+			return fmt.Errorf("The specified directory path does not exist. Please check the path: %s", dirPath)
 		}
-		return fmt.Errorf("An error occurred while accessing the directory path. Please check the path.")
+		return fmt.Errorf("An error occurred while accessing the directory path. Please check the path: %s", dirPath)
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("Expected a directory path but got a file: %s", dirPath)

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -105,7 +105,7 @@ func NewAstCLI(
 
 	_ = rootCmd.PersistentFlags().MarkHidden(params.ApikeyOverrideFlag)
 	rootCmd.PersistentFlags().String(params.LogFileFlag, "", params.LogFileUsage)
-	rootCmd.PersistentFlags().String(params.LogFileStdoutFlag, "", params.LogFileStdUsage)
+	rootCmd.PersistentFlags().String(params.LogFileStdoutFlag, "", params.LogFileStdOutUsage)
 
 	// This monitors and traps situations where "extra/garbage" commands
 	// are passed to Cobra.
@@ -147,7 +147,8 @@ func NewAstCLI(
 	_ = viper.BindPFlag(params.RetryFlag, rootCmd.PersistentFlags().Lookup(params.RetryFlag))
 	_ = viper.BindPFlag(params.RetryDelayFlag, rootCmd.PersistentFlags().Lookup(params.RetryDelayFlag))
 	_ = viper.BindPFlag(params.ApikeyOverrideFlag, rootCmd.PersistentFlags().Lookup(params.ApikeyOverrideFlag))
-
+	_ = viper.BindPFlag(params.LogFileFlag, rootCmd.PersistentFlags().Lookup(params.LogFileFlag))
+	_ = viper.BindPFlag(params.LogFileStdoutFlag, rootCmd.PersistentFlags().Lookup(params.LogFileStdoutFlag))
 	// Set help func
 	rootCmd.SetHelpFunc(
 		func(command *cobra.Command, args []string) {
@@ -415,6 +416,5 @@ func processLogFlag(cmd *cobra.Command, flag string) error {
 		multiWriter = io.MultiWriter(file)
 	}
 	log.SetOutput(multiWriter)
-	viper.Set(params.DebugFlag, true)
 	return nil
 }

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -256,7 +256,7 @@ func Test_stateExclude_not_exploitableRepalceForAllStatesExceptNot_exploitable(t
 }
 func TestSetLogOutputFromFlag_InvalidDir1(t *testing.T) {
 	err := setLogOutputFromFlag(params.LogFileFlag, "/custom/path")
-	assert.ErrorContains(t, err, "The system cannot find the path specified.")
+	assert.ErrorContains(t, err, "The specified directory path does not exist.")
 }
 
 func TestSetLogOutputFromFlag_EmptyDirPath(t *testing.T) {
@@ -272,7 +272,7 @@ func TestSetLogOutputFromFlag_DirPathIsFilePath(t *testing.T) {
 		}
 	}()
 	err = setLogOutputFromFlag(params.LogFileFlag, tempFile.Name())
-	assert.ErrorContains(t, err, "expected a directory path but got a file")
+	assert.ErrorContains(t, err, "Expected a directory path but got a file")
 }
 
 func TestSetLogOutputFromFlag_DirPathPermissionDenied(t *testing.T) {
@@ -282,7 +282,7 @@ func TestSetLogOutputFromFlag_DirPathPermissionDenied(t *testing.T) {
 		_ = os.RemoveAll(path)
 	}(tempDir)
 	err = setLogOutputFromFlag(params.LogFileFlag, tempDir)
-	assert.ErrorContains(t, err, "permission denied: cannot write to directory")
+	assert.ErrorContains(t, err, "Permission denied: cannot write to directory")
 }
 
 func TestSetLogOutputFromFlag_DirPath_Success(t *testing.T) {

--- a/internal/commands/util/usercount/azure.go
+++ b/internal/commands/util/usercount/azure.go
@@ -102,7 +102,7 @@ func createRunAzureUserCountFunc(azureWrapper wrappers.AzureWrapper) func(cmd *c
 		err = printer.Print(cmd.OutOrStdout(), views, format)
 
 		// Only print user count information if in debug mode
-		if viper.GetBool(params.DebugFlag) {
+		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileStdoutFlag) != "" {
 			err = printer.Print(cmd.OutOrStdout(), viewsUsers, format)
 		}
 

--- a/internal/commands/util/usercount/azure.go
+++ b/internal/commands/util/usercount/azure.go
@@ -102,7 +102,7 @@ func createRunAzureUserCountFunc(azureWrapper wrappers.AzureWrapper) func(cmd *c
 		err = printer.Print(cmd.OutOrStdout(), views, format)
 
 		// Only print user count information if in debug mode
-		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileStdoutFlag) != "" {
+		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileConsoleFlag) != "" {
 			err = printer.Print(cmd.OutOrStdout(), viewsUsers, format)
 		}
 

--- a/internal/commands/util/usercount/bitbucket.go
+++ b/internal/commands/util/usercount/bitbucket.go
@@ -97,7 +97,7 @@ func createRunBitBucketUserCountFunc(bitBucketWrapper wrappers.BitBucketWrapper)
 		err = printer.Print(cmd.OutOrStdout(), views, format)
 
 		// Only print user count information if in debug mode
-		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileStdoutFlag) != "" {
+		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileConsoleFlag) != "" {
 			err = printer.Print(cmd.OutOrStdout(), viewsUsers, format)
 		}
 

--- a/internal/commands/util/usercount/bitbucket.go
+++ b/internal/commands/util/usercount/bitbucket.go
@@ -97,7 +97,7 @@ func createRunBitBucketUserCountFunc(bitBucketWrapper wrappers.BitBucketWrapper)
 		err = printer.Print(cmd.OutOrStdout(), views, format)
 
 		// Only print user count information if in debug mode
-		if viper.GetBool(params.DebugFlag) {
+		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileStdoutFlag) != "" {
 			err = printer.Print(cmd.OutOrStdout(), viewsUsers, format)
 		}
 

--- a/internal/commands/util/usercount/bitbucketserver/bitbucket-server.go
+++ b/internal/commands/util/usercount/bitbucketserver/bitbucket-server.go
@@ -116,7 +116,7 @@ func createRunBitBucketServerUserCountFunc(bitBucketServerWrapper bitbucketserve
 		}
 
 		// Only print user count information if in debug mode
-		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileStdoutFlag) != "" {
+		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileConsoleFlag) != "" {
 			err = printer.Print(cmd.OutOrStdout(), viewsUsers, format)
 		}
 

--- a/internal/commands/util/usercount/bitbucketserver/bitbucket-server.go
+++ b/internal/commands/util/usercount/bitbucketserver/bitbucket-server.go
@@ -116,7 +116,7 @@ func createRunBitBucketServerUserCountFunc(bitBucketServerWrapper bitbucketserve
 		}
 
 		// Only print user count information if in debug mode
-		if viper.GetBool(params.DebugFlag) {
+		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileStdoutFlag) != "" {
 			err = printer.Print(cmd.OutOrStdout(), viewsUsers, format)
 		}
 

--- a/internal/commands/util/usercount/github.go
+++ b/internal/commands/util/usercount/github.go
@@ -107,7 +107,7 @@ func createRunGitHubUserCountFunc(gitHubWrapper wrappers.GitHubWrapper) func(cmd
 		err = printer.Print(cmd.OutOrStdout(), views, format)
 
 		// Only print user count information if in debug mode
-		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileStdoutFlag) != "" {
+		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileConsoleFlag) != "" {
 			err = printer.Print(cmd.OutOrStdout(), viewsUsers, format)
 		}
 

--- a/internal/commands/util/usercount/github.go
+++ b/internal/commands/util/usercount/github.go
@@ -107,7 +107,7 @@ func createRunGitHubUserCountFunc(gitHubWrapper wrappers.GitHubWrapper) func(cmd
 		err = printer.Print(cmd.OutOrStdout(), views, format)
 
 		// Only print user count information if in debug mode
-		if viper.GetBool(params.DebugFlag) {
+		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileStdoutFlag) != "" {
 			err = printer.Print(cmd.OutOrStdout(), viewsUsers, format)
 		}
 

--- a/internal/commands/util/usercount/gitlab.go
+++ b/internal/commands/util/usercount/gitlab.go
@@ -95,7 +95,7 @@ func createRunGitLabUserCountFunc(gitLabWrapper wrappers.GitLabWrapper) func(cmd
 		err = printer.Print(cmd.OutOrStdout(), views, format)
 
 		// Only print user count information if in debug mode
-		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileStdoutFlag) != "" {
+		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileConsoleFlag) != "" {
 			err = printer.Print(cmd.OutOrStdout(), viewsUsers, format)
 		}
 

--- a/internal/commands/util/usercount/gitlab.go
+++ b/internal/commands/util/usercount/gitlab.go
@@ -95,7 +95,7 @@ func createRunGitLabUserCountFunc(gitLabWrapper wrappers.GitLabWrapper) func(cmd
 		err = printer.Print(cmd.OutOrStdout(), views, format)
 
 		// Only print user count information if in debug mode
-		if viper.GetBool(params.DebugFlag) {
+		if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileStdoutFlag) != "" {
 			err = printer.Print(cmd.OutOrStdout(), viewsUsers, format)
 		}
 

--- a/internal/logger/utils.go
+++ b/internal/logger/utils.go
@@ -38,7 +38,7 @@ func Printf(msg string, args ...interface{}) {
 }
 
 func PrintIfVerbose(msg string) {
-	if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileStdoutFlag) != "" {
+	if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileConsoleFlag) != "" {
 		Print(msg)
 	}
 }

--- a/internal/logger/utils.go
+++ b/internal/logger/utils.go
@@ -38,7 +38,7 @@ func Printf(msg string, args ...interface{}) {
 }
 
 func PrintIfVerbose(msg string) {
-	if viper.GetBool(params.DebugFlag) {
+	if viper.GetBool(params.DebugFlag) || viper.GetString(params.LogFileFlag) != "" || viper.GetString(params.LogFileStdoutFlag) != "" {
 		Print(msg)
 	}
 }

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -157,7 +157,10 @@ const (
 	ScaHideDevAndTestDepFlag     = "sca-hide-dev-test-dependencies"
 	LimitFlag                    = "limit"
 	ConfigFilePathFlag           = "config-file-path"
-
+	LogFileFlag                  = "log-file"
+	LogFileUsage                 = "Path to the debug log file"
+	LogFileStdFlag               = "log-file-std"
+	LogFileStdUsage              = "Print log to both console and a file"
 	// INDIVIDUAL FILTER FLAGS
 	SastFilterFlag  = "sast-filter"
 	SastFilterUsage = "SAST filter"

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -160,7 +160,7 @@ const (
 	LogFileFlag                  = "log-file"
 	LogFileUsage                 = "Path to the debug log file"
 	LogFileStdoutFlag            = "log-file-stdout"
-	LogFileStdUsage              = "Print log to both console and a file"
+	LogFileStdOutUsage           = "Print log to both console and a file"
 	// INDIVIDUAL FILTER FLAGS
 	SastFilterFlag  = "sast-filter"
 	SastFilterUsage = "SAST filter"

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -159,7 +159,7 @@ const (
 	ConfigFilePathFlag           = "config-file-path"
 	LogFileFlag                  = "log-file"
 	LogFileUsage                 = "Path to the debug log file"
-	LogFileStdFlag               = "log-file-std"
+	LogFileStdoutFlag            = "log-file-stdout"
 	LogFileStdUsage              = "Print log to both console and a file"
 	// INDIVIDUAL FILTER FLAGS
 	SastFilterFlag  = "sast-filter"

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -158,9 +158,9 @@ const (
 	LimitFlag                    = "limit"
 	ConfigFilePathFlag           = "config-file-path"
 	LogFileFlag                  = "log-file"
-	LogFileUsage                 = "Path to the debug log file"
-	LogFileStdoutFlag            = "log-file-stdout"
-	LogFileStdOutUsage           = "Print log to both console and a file"
+	LogFileUsage                 = "Saves logs to the specified file path only."
+	LogFileConsoleFlag           = "log-file-console"
+	LogFileConsoleUsage          = "Saves logs to the specified file path as well as to the console."
 	// INDIVIDUAL FILTER FLAGS
 	SastFilterFlag  = "sast-filter"
 	SastFilterUsage = "SAST filter"

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -158,9 +158,9 @@ const (
 	LimitFlag                    = "limit"
 	ConfigFilePathFlag           = "config-file-path"
 	LogFileFlag                  = "log-file"
-	LogFileUsage                 = "Saves logs to the specified file path only."
+	LogFileUsage                 = "Saves logs to the specified file path only"
 	LogFileConsoleFlag           = "log-file-console"
-	LogFileConsoleUsage          = "Saves logs to the specified file path as well as to the console."
+	LogFileConsoleUsage          = "Saves logs to the specified file path as well as to the console"
 	// INDIVIDUAL FILTER FLAGS
 	SastFilterFlag  = "sast-filter"
 	SastFilterUsage = "SAST filter"

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -268,7 +268,7 @@ func SendHTTPRequestByFullURLContentLength(
 
 func addReqMonitor(req *http.Request) *http.Request {
 	startTime := time.Now().UnixNano() / int64(time.Millisecond)
-	if viper.GetBool(commonParams.DebugFlag) {
+	if viper.GetBool(commonParams.DebugFlag) || viper.GetString(commonParams.LogFileFlag) != "" || viper.GetString(commonParams.LogFileStdoutFlag) != "" {
 		trace := &httptrace.ClientTrace{
 			GetConn: func(hostPort string) {
 				startTime = time.Now().UnixNano() / int64(time.Millisecond)

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -268,7 +268,7 @@ func SendHTTPRequestByFullURLContentLength(
 
 func addReqMonitor(req *http.Request) *http.Request {
 	startTime := time.Now().UnixNano() / int64(time.Millisecond)
-	if viper.GetBool(commonParams.DebugFlag) || viper.GetString(commonParams.LogFileFlag) != "" || viper.GetString(commonParams.LogFileStdoutFlag) != "" {
+	if viper.GetBool(commonParams.DebugFlag) || viper.GetString(commonParams.LogFileFlag) != "" || viper.GetString(commonParams.LogFileConsoleFlag) != "" {
 		trace := &httptrace.ClientTrace{
 			GetConn: func(hostPort string) {
 				startTime = time.Now().UnixNano() / int64(time.Millisecond)

--- a/test/integration/root_test.go
+++ b/test/integration/root_test.go
@@ -127,7 +127,7 @@ func isFFEnabled(t *testing.T, featureFlag string) bool {
 
 func TestSetLogOutputFromFlag_InvalidDir(t *testing.T) {
 	err, _ := executeCommand(t, "auth", "validate", "--log-file", "/custom/path")
-	assert.ErrorContains(t, err, "The system cannot find the path specified.")
+	assert.ErrorContains(t, err, "The specified directory path does not exist.")
 }
 
 func TestSetLogOutputFromFlag_EmptyDirPath(t *testing.T) {
@@ -141,7 +141,7 @@ func TestSetLogOutputFromFlag_DirPathIsFilePath(t *testing.T) {
 		_ = os.Remove(path)
 	}(tempFile.Name())
 	err, _ = executeCommand(t, "auth", "validate", "--log-file", tempFile.Name())
-	assert.ErrorContains(t, err, "expected a directory path but got a file")
+	assert.ErrorContains(t, err, "Expected a directory path but got a file")
 }
 
 func TestSetLogOutputFromFlag_DirPathPermissionDenied(t *testing.T) {
@@ -151,7 +151,7 @@ func TestSetLogOutputFromFlag_DirPathPermissionDenied(t *testing.T) {
 		_ = os.RemoveAll(path)
 	}(tempDir)
 	err, _ = executeCommand(t, "auth", "validate", "--log-file", tempDir)
-	assert.ErrorContains(t, err, "permission denied: cannot write to directory")
+	assert.ErrorContains(t, err, "Permission denied: cannot write to directory")
 }
 
 func TestSetLogOutputFromFlag_DirPath_Success(t *testing.T) {

--- a/test/integration/util_command.go
+++ b/test/integration/util_command.go
@@ -223,7 +223,7 @@ func executeCmdWithTimeOutNilAssertion(
 func executeWithTimeout(cmd *cobra.Command, timeout time.Duration, args ...string) error {
 
 	args = append(args, flag(params.RetryFlag), "3", flag(params.RetryDelayFlag), "5")
-	//args = appendProxyArgs(args)
+	args = appendProxyArgs(args)
 	cmd.SetArgs(args)
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/test/integration/util_command.go
+++ b/test/integration/util_command.go
@@ -223,7 +223,7 @@ func executeCmdWithTimeOutNilAssertion(
 func executeWithTimeout(cmd *cobra.Command, timeout time.Duration, args ...string) error {
 
 	args = append(args, flag(params.RetryFlag), "3", flag(params.RetryDelayFlag), "5")
-	args = appendProxyArgs(args)
+	//args = appendProxyArgs(args)
 	cmd.SetArgs(args)
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)


### PR DESCRIPTION
**By submitting this pull request, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please review the [contributing guidelines](../docs/contributing.md) for guidance on creating high-quality pull requests.**

## Description

Following are the two new CLI flags created that will redirect the output to a file instead of default stdout.
--log-file string                   Saves logs to the specified file path only.
--log-file-console string     Saves logs to the specified file path as well as to the console.

Both the flags are the optional flags, default log output will be console only.
--log-file <file_path>
      This flag is used to redirect the log output to custom file path.

--log-file-console <file_path>
      This flag is used to redirect the log output to custom file path as well as console.


## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

*Link any related issues or tickets.*

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable)
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used

## Screenshots (if applicable)

*Add screenshots to help explain your changes.*

## Additional Notes

*Add any other relevant information.*
