### PR TITLE
Add new SSCS licensing (WIP)

### DIFF
--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -286,8 +286,12 @@ const (
 	Success                        = "success"
 	SCSScorecardType               = "sscs-scorecard"
 	SCSSecretDetectionType         = "sscs-secret-detection"
+	SecretDetectionType            = "secret-detection"
+	SecretDetectionLabel           = "Secret Detection"
 	EnterpriseSecretsLabel         = "Enterprise Secrets"
 	EnterpriseSecretsType          = "enterprise-secrets"
+	RepositoryHealthType           = "repository-health"
+	RepositoryHealthLabel          = "Repository Health"
 	SCSScorecardOverviewType       = "Scorecard"
 	SCSSecretDetectionOverviewType = "2ms"
 )

--- a/internal/wrappers/feature-flags.go
+++ b/internal/wrappers/feature-flags.go
@@ -15,7 +15,7 @@ const SastCustomStateEnabled = "SAST_CUSTOM_STATES_ENABLED"
 const SCSEngineCLIEnabled = "NEW_2MS_SCORECARD_RESULTS_CLI_ENABLED"
 const RiskManagementEnabled = "RISK_MANAGEMENT_IDES_PROJECT_RESULTS_SCORES_API_ENABLED"
 const OssRealtimeEnabled = "OSS_REALTIME_ENABLED"
-const SscsNewLicensingEnabled = "SSCS_NEW_LICENSING_ENABLED"
+const SscsLicensingV2Enabled = "SSCS_NEW_LICENSING_ENABLED"
 const maxRetries = 3
 
 var DefaultFFLoad bool = false

--- a/internal/wrappers/feature-flags.go
+++ b/internal/wrappers/feature-flags.go
@@ -15,6 +15,7 @@ const SastCustomStateEnabled = "SAST_CUSTOM_STATES_ENABLED"
 const SCSEngineCLIEnabled = "NEW_2MS_SCORECARD_RESULTS_CLI_ENABLED"
 const RiskManagementEnabled = "RISK_MANAGEMENT_IDES_PROJECT_RESULTS_SCORES_API_ENABLED"
 const OssRealtimeEnabled = "OSS_REALTIME_ENABLED"
+const SscsNewLicensingEnabled = "SSCS_NEW_LICENSING_ENABLED"
 const maxRetries = 3
 
 var DefaultFFLoad bool = false

--- a/internal/wrappers/mock/jwt-helper-mock.go
+++ b/internal/wrappers/mock/jwt-helper-mock.go
@@ -9,21 +9,23 @@ import (
 type JWTMockWrapper struct {
 	AIEnabled               int
 	CustomGetAllowedEngines func(wrappers.FeatureFlagsWrapper) (map[string]bool, error)
+	SscsNewLicensing        bool
 }
 
 const AIProtectionDisabled = 1
 
 // GetAllowedEngines mock for tests
-func (j *JWTMockWrapper) GetAllowedEngines(featureFlagsWrapper wrappers.FeatureFlagsWrapper) (allowedEngines map[string]bool, err error) {
+func (j *JWTMockWrapper) GetAllowedEngines(featureFlagsWrapper wrappers.FeatureFlagsWrapper) (allowedEngines map[string]bool, sscsNewLicensing bool, err error) {
 	if j.CustomGetAllowedEngines != nil {
-		return j.CustomGetAllowedEngines(featureFlagsWrapper)
+		allowedEngines, err = j.CustomGetAllowedEngines(featureFlagsWrapper)
+		return allowedEngines, j.SscsNewLicensing, err
 	}
 	allowedEngines = make(map[string]bool)
 	engines := []string{"sast", "iac-security", "sca", "api-security", "containers", "scs"}
 	for _, value := range engines {
 		allowedEngines[strings.ToLower(value)] = true
 	}
-	return allowedEngines, nil
+	return allowedEngines, j.SscsNewLicensing, nil
 }
 
 func (*JWTMockWrapper) ExtractTenantFromToken() (tenant string, err error) {

--- a/internal/wrappers/mock/jwt-helper-mock.go
+++ b/internal/wrappers/mock/jwt-helper-mock.go
@@ -9,23 +9,23 @@ import (
 type JWTMockWrapper struct {
 	AIEnabled               int
 	CustomGetAllowedEngines func(wrappers.FeatureFlagsWrapper) (map[string]bool, error)
-	SscsNewLicensing        bool
+	SscsLicensingV2         bool
 }
 
 const AIProtectionDisabled = 1
 
 // GetAllowedEngines mock for tests
-func (j *JWTMockWrapper) GetAllowedEngines(featureFlagsWrapper wrappers.FeatureFlagsWrapper) (allowedEngines map[string]bool, sscsNewLicensing bool, err error) {
+func (j *JWTMockWrapper) GetAllowedEngines(featureFlagsWrapper wrappers.FeatureFlagsWrapper) (allowedEngines map[string]bool, sscsLicensingV2 bool, err error) {
 	if j.CustomGetAllowedEngines != nil {
 		allowedEngines, err = j.CustomGetAllowedEngines(featureFlagsWrapper)
-		return allowedEngines, j.SscsNewLicensing, err
+		return allowedEngines, j.SscsLicensingV2, err
 	}
 	allowedEngines = make(map[string]bool)
 	engines := []string{"sast", "iac-security", "sca", "api-security", "containers", "scs"}
 	for _, value := range engines {
 		allowedEngines[strings.ToLower(value)] = true
 	}
-	return allowedEngines, j.SscsNewLicensing, nil
+	return allowedEngines, j.SscsLicensingV2, nil
 }
 
 func (*JWTMockWrapper) ExtractTenantFromToken() (tenant string, err error) {


### PR DESCRIPTION
**By submitting this pull request, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please review the [contributing guidelines](../docs/contributing.md) for guidance on creating high-quality pull requests.**

## Description

Epic: https://checkmarx.atlassian.net/browse/AST-75500

We want do add the new licensing logic under the SSCS_NEW_LICENSING_ENABLED feature flag:
 - SCS will be renamed to Repository Health
 - Enterprise Secrets will be renamed to Secret Detection
 - Repository Health and Secret Detection will have independent licenses (previously, enabling Enterprise Secrets required also having SCS).
 - The SSCS engine will run only if at least one of the two micro-engines is both enabled and licensed.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

TODO

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable)
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
