### PR TITLE
Support SCS Secret Detection results for Jetbrains agent in JSON report(AST-110764)

### DIFF
--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -1158,7 +1158,7 @@ func filterResultsByType(results *wrappers.ScanResultsCollection, excludedTypes 
 func filterScsResultsByAgent(results *wrappers.ScanResultsCollection, agent string) *wrappers.ScanResultsCollection {
 	unsupportedTypesByAgent := map[string][]string{
 		commonParams.VSCodeAgent:       {commonParams.SCSScorecardType},
-		commonParams.JetbrainsAgent:    {commonParams.SCSScorecardType, commonParams.SCSSecretDetectionType},
+		commonParams.JetbrainsAgent:    {commonParams.SCSScorecardType},
 		commonParams.EclipseAgent:      {commonParams.SCSScorecardType, commonParams.SCSSecretDetectionType},
 		commonParams.VisualStudioAgent: {commonParams.SCSScorecardType, commonParams.SCSSecretDetectionType},
 	}

--- a/internal/commands/result_test.go
+++ b/internal/commands/result_test.go
@@ -206,8 +206,8 @@ func TestRunScsResultsShow_Other_AgentsShouldNotShowScsResults(t *testing.T) {
 
 	execCmdNilAssertion(t, "results", "show", "--scan-id", "SCS_ONLY", "--report-format", "json", "--agent", params.JetbrainsAgent)
 	assertTypePresentJSON(t, params.SCSScorecardType, 0)
-	assertTypePresentJSON(t, params.SCSSecretDetectionType, 0)
-	assertTotalCountJSON(t, 0)
+	assertTypePresentJSON(t, params.SCSSecretDetectionType, 2)
+	assertTotalCountJSON(t, 2)
 
 	removeFileBySuffix(t, printer.FormatJSON)
 	mock.SetScsMockVarsToDefault()


### PR DESCRIPTION
**By submitting this pull request, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please review the [contributing guidelines](../docs/contributing.md) for guidance on creating high-quality pull requests.**

## Description

1. This PR updates the SCS results filtering logic for Jetbrains agent in the CLI.
2. When generating results with --report-format json and agent set to Jetbrains, only SCS Scorecard results are excluded; SCS Secret Detection results are now included.
3. This matches the behavior for VS Code agent and ensures consistency across IDE integrations.
4. Unit tests have been updated to verify the correct filtering for Jetbrains, VS Code, AST-CLI, and other agents.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

[AST-110764](https://checkmarx.atlassian.net/browse/AST-110764)
[AST-105453](https://checkmarx.atlassian.net/browse/AST-105453)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable)
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used

## Screenshots (if applicable)

*Add screenshots to help explain your changes.*

## Additional Notes

- No breaking changes.
- Behavior for VS Code and AST-CLI agents remains unchanged.
- Other agents continue to exclude all SCS results.


[AST-110764]: https://checkmarx.atlassian.net/browse/AST-110764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ