### PR TITLE
Fix GitHub API rate limit exceeds for contributor count command(AST-114776)

### DIFF
--- a/internal/commands/rate_limit_test.go
+++ b/internal/commands/rate_limit_test.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"github.com/checkmarx/ast-cli/internal/wrappers"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func mockAPI(repeatCode int, repeatCount int, headerName, headerValue string) func() (*http.Response, error) {
+	attempt := 0
+	return func() (*http.Response, error) {
+		rec := httptest.NewRecorder()
+		if attempt < repeatCount {
+			rec.Code = repeatCode
+			if headerName != "" {
+				rec.Header().Set(headerName, headerValue)
+			}
+		} else {
+			rec.Code = http.StatusOK
+		}
+		attempt++
+		return rec.Result(), nil
+	}
+}
+func TestGitHubRateLimit_SuccessAfterRetryOne(t *testing.T) {
+	reset := strconv.FormatInt(time.Now().Unix()+20, 10) // simulate 20-second wait
+	api := mockAPI(403, 1, "X-RateLimit-Reset", reset)
+
+	start := time.Now()
+	resp, err := wrappers.WithSCMRateLimitRetry(wrappers.GitHubRateLimitConfig, api)
+	elapsed := time.Since(start)
+
+	asserts := assert.New(t)
+	asserts.NoError(err)
+	asserts.Equal(http.StatusOK, resp.StatusCode)
+	asserts.GreaterOrEqual(elapsed, 20*time.Second)
+}
+
+func TestGitHubRateLimit_SuccessAfterRetryTwo(t *testing.T) {
+	reset := strconv.FormatInt(time.Now().Unix()+20, 10) // simulate 20-second wait
+	api := mockAPI(429, 2, "X-RateLimit-Reset", reset)
+
+	start := time.Now()
+	resp, err := wrappers.WithSCMRateLimitRetry(wrappers.GitHubRateLimitConfig, api)
+	elapsed := time.Since(start)
+
+	asserts := assert.New(t)
+	asserts.NoError(err)
+	asserts.Equal(http.StatusOK, resp.StatusCode)
+	asserts.GreaterOrEqual(elapsed, 20*time.Second)
+}
+
+func TestGitHubRateLimit_SuccessAfterRetryThree(t *testing.T) {
+	reset := strconv.FormatInt(time.Now().Unix()+20, 10) // simulate 20-second wait
+	api := mockAPI(403, 3, "X-RateLimit-Reset", reset)
+
+	start := time.Now()
+	resp, err := wrappers.WithSCMRateLimitRetry(wrappers.GitHubRateLimitConfig, api)
+	elapsed := time.Since(start)
+
+	asserts := assert.New(t)
+	asserts.NoError(err)
+	asserts.Equal(http.StatusOK, resp.StatusCode)
+	asserts.GreaterOrEqual(elapsed, 20*time.Second)
+}
+
+func TestGitLabRateLimit_SuccessAfterRetryOne(t *testing.T) {
+	reset := strconv.FormatInt(time.Now().Unix()+20, 10) // simulate 20-second wait
+	api := mockAPI(429, 1, "Retry-After", reset)
+
+	start := time.Now()
+	resp, err := wrappers.WithSCMRateLimitRetry(wrappers.GitLabRateLimitConfig, api)
+	elapsed := time.Since(start)
+
+	asserts := assert.New(t)
+	asserts.NoError(err)
+	asserts.Equal(http.StatusOK, resp.StatusCode)
+	asserts.GreaterOrEqual(elapsed, 20*time.Second)
+}
+
+func TestBitBucketRateLimit_SuccessAfterRetryOne(t *testing.T) {
+	reset := strconv.FormatInt(time.Now().Unix()+20, 10) // simulate 20-second wait
+	api := mockAPI(429, 1, "Retry-After", reset)
+
+	start := time.Now()
+	resp, err := wrappers.WithSCMRateLimitRetry(wrappers.BitbucketRateLimitConfig, api)
+	elapsed := time.Since(start)
+
+	asserts := assert.New(t)
+	asserts.NoError(err)
+	asserts.Equal(http.StatusOK, resp.StatusCode)
+	asserts.GreaterOrEqual(elapsed, 20*time.Second)
+}
+
+func TestAzureRateLimit_SuccessAfterRetryOne(t *testing.T) {
+	reset := strconv.FormatInt(time.Now().Unix()+20, 10) // simulate 20-second wait
+	api := mockAPI(429, 1, "X-Ratelimit-Reset", reset)
+
+	start := time.Now()
+	resp, err := wrappers.WithSCMRateLimitRetry(wrappers.AzureRateLimitConfig, api)
+	elapsed := time.Since(start)
+
+	asserts := assert.New(t)
+	asserts.NoError(err)
+	asserts.Equal(http.StatusOK, resp.StatusCode)
+	asserts.GreaterOrEqual(elapsed, 20*time.Second)
+}

--- a/internal/wrappers/azure-http.go
+++ b/internal/wrappers/azure-http.go
@@ -108,7 +108,12 @@ func (g *AzureHTTPWrapper) get(
 	queryParams map[string]string,
 	authFormat string,
 ) (bool, error) {
-	resp, err := GetWithQueryParams(g.client, url, token, authFormat, queryParams)
+	resp, err := WithSCMRateLimitRetry(
+		AzureRateLimitConfig,
+		func() (*http.Response, error) {
+			return GetWithQueryParams(g.client, url, token, authFormat, queryParams)
+		},
+	)
 	if err != nil {
 		return false, err
 	}

--- a/internal/wrappers/bitbucket-http.go
+++ b/internal/wrappers/bitbucket-http.go
@@ -150,7 +150,12 @@ func (g *BitBucketHTTPWrapper) getFromBitBucket(
 
 	logger.PrintIfVerbose(fmt.Sprintf("Request to %s", url))
 
-	resp, err := GetWithQueryParams(g.client, url, token, basicFormat, queryParams)
+	resp, err := WithSCMRateLimitRetry(
+		BitbucketRateLimitConfig,
+		func() (*http.Response, error) {
+			return GetWithQueryParams(g.client, url, token, basicFormat, queryParams)
+		},
+	)
 	if err != nil {
 		return err
 	}
@@ -264,7 +269,12 @@ func collectPageBitBucket(
 }
 
 func getBitBucket(client *http.Client, token, url string, target interface{}, queryParams map[string]string) error {
-	resp, err := GetWithQueryParams(client, url, token, basicFormat, queryParams)
+	resp, err := WithSCMRateLimitRetry(
+		BitbucketRateLimitConfig,
+		func() (*http.Response, error) {
+			return GetWithQueryParams(client, url, token, basicFormat, queryParams)
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/wrappers/bitbucketserver/bitbucket-server-http.go
+++ b/internal/wrappers/bitbucketserver/bitbucket-server-http.go
@@ -162,7 +162,12 @@ func getBitBucketServer(
 	}
 
 	req.URL.RawQuery = q.Encode()
-	resp, err := client.Do(req)
+	resp, err := wrappers.WithSCMRateLimitRetry(
+		wrappers.BitbucketRateLimitConfig,
+		func() (*http.Response, error) {
+			return client.Do(req)
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/wrappers/github-http.go
+++ b/internal/wrappers/github-http.go
@@ -244,7 +244,12 @@ func get(client *http.Client, url string, target interface{}, queryParams map[st
 	req.Header.Add(acceptHeader, apiVersion)
 	token := viper.GetString(params.SCMTokenFlag)
 	logger.PrintRequest(req)
-	resp, err := GetWithQueryParamsAndCustomRequest(client, req, url, token, tokenFormat, queryParams)
+	resp, err := WithSCMRateLimitRetry(
+		GitHubRateLimitConfig,
+		func() (*http.Response, error) {
+			return GetWithQueryParamsAndCustomRequest(client, req, url, token, tokenFormat, queryParams)
+		},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/wrappers/gitlab-http.go
+++ b/internal/wrappers/gitlab-http.go
@@ -137,7 +137,12 @@ func getFromGitLab(
 
 	logger.PrintRequest(req)
 
-	resp, err := GetWithQueryParamsAndCustomRequest(client, req, requestURL, token, bearerFormat, queryParams)
+	resp, err := WithSCMRateLimitRetry(
+		GitLabRateLimitConfig,
+		func() (*http.Response, error) {
+			return GetWithQueryParamsAndCustomRequest(client, req, requestURL, token, bearerFormat, queryParams)
+		},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/wrappers/rate_limit.go
+++ b/internal/wrappers/rate_limit.go
@@ -1,0 +1,173 @@
+package wrappers
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// SCMRateLimitConfig holds rate limit configuration for different SCM providers
+type SCMRateLimitConfig struct {
+	Provider             string
+	ResetHeaderName      string
+	RemainingHeaderName  string
+	LimitHeaderName      string
+	RateLimitStatusCodes []int
+	DefaultWaitTime      time.Duration
+}
+
+// Common SCM rate limit configurations
+var (
+	GitHubRateLimitConfig = SCMRateLimitConfig{
+		Provider:             "GitHub",
+		ResetHeaderName:      "X-RateLimit-Reset",
+		RemainingHeaderName:  "X-RateLimit-Remaining",
+		LimitHeaderName:      "X-RateLimit-Limit",
+		RateLimitStatusCodes: []int{403, 429},
+		DefaultWaitTime:      60 * time.Second,
+	}
+
+	GitLabRateLimitConfig = SCMRateLimitConfig{
+		Provider:             "GitLab",
+		ResetHeaderName:      "Retry-After",
+		RemainingHeaderName:  "", // GitLab does not provide remaining limit in headers
+		LimitHeaderName:      "", // GitLab does not provide limit in headers
+		RateLimitStatusCodes: []int{429},
+		DefaultWaitTime:      60 * time.Second,
+	}
+
+	BitbucketRateLimitConfig = SCMRateLimitConfig{
+		Provider:             "Bitbucket",
+		ResetHeaderName:      "Retry-After",
+		RemainingHeaderName:  "", // Bitbucket does not provide remaining limit in headers
+		LimitHeaderName:      "", // Bitbucket does not provide limit in headers
+		RateLimitStatusCodes: []int{429},
+		DefaultWaitTime:      60 * time.Second,
+	}
+
+	AzureRateLimitConfig = SCMRateLimitConfig{
+		Provider:             "Azure",
+		ResetHeaderName:      "Retry-After",
+		RemainingHeaderName:  "", // Azure does not provide remaining limit in headers
+		LimitHeaderName:      "", // Azure does not provide limit in headers
+		RateLimitStatusCodes: []int{429},
+		DefaultWaitTime:      60 * time.Second,
+	}
+)
+
+// SCMRateLimitError represents a rate limit error from any SCM provider
+type SCMRateLimitError struct {
+	Provider  string
+	ResetTime int64
+	Message   string
+}
+
+func (e *SCMRateLimitError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return e.Provider + " API rate limit exceeded"
+}
+
+func (e *SCMRateLimitError) RetryAfter() time.Duration {
+	switch e.Provider {
+	case "GitHub":
+		if e.ResetTime > 0 {
+			reset := time.Unix(e.ResetTime, 0)
+			now := time.Now()
+			if reset.After(now) {
+				return reset.Sub(now) + time.Second
+			}
+		}
+		return 60 * time.Second
+	case "GitLab", "Bitbucket", "Azure":
+		if e.ResetTime > 0 {
+			return (time.Duration(e.ResetTime) * time.Second) + time.Second
+		}
+		return 60 * time.Second
+	default:
+		return 60 * time.Second
+	}
+}
+
+// WithSCMRateLimitRetry wraps any SCM API call with rate limit retry logic
+func WithSCMRateLimitRetry(config SCMRateLimitConfig, apiCall func() (*http.Response, error)) (*http.Response, error) {
+	maxRetries := 3
+	retryCount := 0
+
+	for {
+		resp, err := apiCall()
+		if err != nil {
+			return nil, err
+		}
+
+		// Check if it's a rate limit error
+		if isRateLimitStatusCode(resp.StatusCode, config) {
+			rateLimitErr := ParseRateLimitHeaders(resp.Header, config)
+			wait := config.DefaultWaitTime
+			if rateLimitErr != nil {
+				wait = rateLimitErr.RetryAfter()
+			}
+			if retryCount >= maxRetries {
+				return nil, errors.Errorf("%s API rate limit exceeded after %d retries", config.Provider, maxRetries)
+			}
+			log.Printf("%s API rate limit exceeded (status %d). Waiting %v until %v before retrying... (attempt %d/%d)",
+				config.Provider, resp.StatusCode, wait, time.Now().Add(wait), retryCount+1, maxRetries)
+			time.Sleep(wait)
+			// Reset Authorization header before retry
+			if resp.Request != nil {
+				resetAuthorizationHeader(resp.Request)
+			}
+			retryCount++
+			continue
+		}
+		return resp, err
+	}
+}
+
+// ParseRateLimitHeaders extracts rate limit information from HTTP response headers
+func ParseRateLimitHeaders(headers map[string][]string, config SCMRateLimitConfig) *SCMRateLimitError {
+	resetHeader := getHeaderValue(headers, config.ResetHeaderName)
+	if resetHeader == "" {
+		return nil
+	}
+
+	resetTime, err := strconv.ParseInt(resetHeader, 10, 64)
+	if err != nil {
+		return nil
+	}
+
+	return &SCMRateLimitError{
+		Provider:  config.Provider,
+		ResetTime: resetTime,
+	}
+}
+
+// getHeaderValue retrieves a header value in a case-insensitive manner
+func getHeaderValue(headers map[string][]string, headerName string) string {
+	for name, values := range headers {
+		if strings.EqualFold(name, headerName) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
+// isRateLimitStatusCode checks if the status code indicates a rate limit error
+func isRateLimitStatusCode(statusCode int, config SCMRateLimitConfig) bool {
+	for _, code := range config.RateLimitStatusCodes {
+		if statusCode == code {
+			return true
+		}
+	}
+	return false
+}
+
+// resetAuthorizationHeader removes the Authorization header from the request
+func resetAuthorizationHeader(req *http.Request) {
+	req.Header.Del("Authorization")
+}


### PR DESCRIPTION
**By submitting this pull request, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please review the [contributing guidelines](../docs/contributing.md) for guidance on creating high-quality pull requests.**

## Description

*Fix GitHub API rate limit exceeds for contributor count command by retry mechanism*

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Related Issues

*Link any related issues or tickets.*

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used

## Screenshots (if applicable)

*Add screenshots to help explain your changes.*

## Additional Notes

*Add any other relevant information.*
