### PR TITLE
fix: iac-security-filter flag ignoring passed parameters (AST-145741)

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -788,8 +788,8 @@ func scanCreateSubCommand(
 		commonParams.Branch, commonParams.BranchFlagUsage,
 	)
 	createScanCmd.PersistentFlags().String(commonParams.SastFilterFlag, "", commonParams.SastFilterUsage)
-	createScanCmd.PersistentFlags().String(commonParams.IacsFilterFlag, "", commonParams.IacsFilterUsage)
-	createScanCmd.PersistentFlags().String(commonParams.KicsFilterFlag, "", commonParams.KicsFilterUsage)
+	createScanCmd.PersistentFlags().StringSlice(commonParams.IacsFilterFlag, []string{}, commonParams.IacsFilterUsage)
+	createScanCmd.PersistentFlags().StringSlice(commonParams.KicsFilterFlag, []string{}, commonParams.KicsFilterUsage)
 
 	err = createScanCmd.PersistentFlags().MarkDeprecated(commonParams.KicsFilterFlag, "please use the replacement flag --iac-security-filter")
 	if err != nil {

--- a/internal/commands/scan_test.go
+++ b/internal/commands/scan_test.go
@@ -1198,6 +1198,55 @@ func TestAddKicsScan(t *testing.T) {
 	}
 }
 
+func TestAddKicsScanWithIacsFilter(t *testing.T) {
+	var resubmitConfig []wrappers.Config
+
+	cmdCommand := &cobra.Command{
+		Use:   "scan",
+		Short: "Scan a project",
+		Long:  `Scan a project`,
+	}
+
+	cmdCommand.PersistentFlags().StringSlice(
+		commonParams.KicsFilterFlag,
+		[]string{},
+		"Filter for KICS scan",
+	)
+
+	cmdCommand.PersistentFlags().StringSlice(
+		commonParams.IacsFilterFlag,
+		[]string{},
+		"IaC filter",
+	)
+
+	cmdCommand.PersistentFlags().StringSlice(
+		commonParams.IacsPlatformsFlag,
+		[]string{},
+		"IaC platforms",
+	)
+
+	_ = cmdCommand.Execute()
+
+	// Set the new --iac-security-filter flag (not the deprecated --kics-filter)
+	_ = cmdCommand.Flags().Set(commonParams.IacsFilterFlag, "!docker-compose.yaml")
+
+	result := addKicsScan(cmdCommand, resubmitConfig)
+
+	expectedConfig := wrappers.KicsConfig{
+		Filter: "!docker-compose.yaml",
+	}
+
+	if result[resultsMapType] != commonParams.KicsType {
+		t.Errorf("Expected type %s, got %v", commonParams.KicsType, result[resultsMapType])
+	}
+
+	actualConfig := result[resultsMapValue].(*wrappers.KicsConfig)
+
+	if !reflect.DeepEqual(actualConfig, &expectedConfig) {
+		t.Errorf("--iac-security-filter value was not propagated to scan config: expected %+v, got %+v", expectedConfig, actualConfig)
+	}
+}
+
 func TestCreateScanProjectTagsCheckResendToScan(t *testing.T) {
 	baseArgs := []string{"scan", "create", "--project-name", "sastFilterMock", "-b", "dummy_branch", "-s", dummyRepo, "--project-tags", "SEG", "--debug"}
 	cmd := createASTTestCommand()


### PR DESCRIPTION
**By submitting this pull request, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please review the [contributing guidelines](../docs/contributing.md) for guidance on creating high-quality pull requests.**

## Description

Flag --iac-security-filter (and its deprecated alias --kics-filter) was registered as a String flag in internal/commands/scan.go, but deprecatedFlagValue() reads it using GetStringSlice. This silently returns an empty slice, causing the filter value to be dropped and never sent to the API. As a result, the filter had no effect and files that should have been excluded were still scanned.

Fixed by registering both flags as StringSlice, consistent with how --iac-security-platforms / --kics-platforms are registered.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

*Link any related issues or tickets.*

https://checkmarx.atlassian.net/browse/AST-145741

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable)
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used

## Screenshots (if applicable)

*Add screenshots to help explain your changes.*

## Additional Notes

*Add any other relevant information.*
