### PR TITLE
Add .vm file extension to scan include filters (AST-148814)

### DIFF
--- a/internal/params/filters.go
+++ b/internal/params/filters.go
@@ -149,6 +149,8 @@ var BaseIncludeFilters = []string{
 	"*.cts",
 	"*.html",
 	"*.xhtml",
+	"*.xhtml",
+	"*.vm",
 }
 
 var BaseExcludeFilters = []string{

--- a/internal/services/applications.go
+++ b/internal/services/applications.go
@@ -112,7 +112,8 @@ func findApplicationAndUpdate(applicationName string, applicationsWrapper wrappe
 	return nil
 }
 
-func checkDirectAssociationEnabled(featureFlagsWrapper wrappers.FeatureFlagsWrapper, tenantWrapper wrappers.TenantConfigurationWrapper) (bool, error) {
+func checkDirectAssociationEnabled(featureFlagsWrapper wrappers.FeatureFlagsWrapper, tenantWrapper wrappers.TenantConfigurationWrapper) 
+(bool, error) {
 	directAssociationEnabled, _ := wrappers.GetSpecificFeatureFlag(featureFlagsWrapper, wrappers.DirectAssociationEnabled)
 	daMigrationEnabled, _ := wrappers.GetSpecificFeatureFlag(featureFlagsWrapper, wrappers.DaMigrationEnabled)
 	var isDAConfigurationEnabled bool

--- a/internal/services/applications.go
+++ b/internal/services/applications.go
@@ -112,8 +112,7 @@ func findApplicationAndUpdate(applicationName string, applicationsWrapper wrappe
 	return nil
 }
 
-func checkDirectAssociationEnabled(featureFlagsWrapper wrappers.FeatureFlagsWrapper, tenantWrapper wrappers.TenantConfigurationWrapper) 
-(bool, error) {
+func checkDirectAssociationEnabled(featureFlagsWrapper wrappers.FeatureFlagsWrapper, tenantWrapper wrappers.TenantConfigurationWrapper) (bool, error) {
 	directAssociationEnabled, _ := wrappers.GetSpecificFeatureFlag(featureFlagsWrapper, wrappers.DirectAssociationEnabled)
 	daMigrationEnabled, _ := wrappers.GetSpecificFeatureFlag(featureFlagsWrapper, wrappers.DaMigrationEnabled)
 	var isDAConfigurationEnabled bool


### PR DESCRIPTION
## Summary
- Added `*.vm` (Apache Velocity template) to the `BaseIncludeFilters` list in `internal/params/filters.go` so that `.vm` files are included during scans.


🤖 Generated with [Claude Code](https://claude.com/claude-code)