### PR TITLE
Bug fix: Convert IacsFilterFlag and KicsFilterFlag to StringSlice (AST-145741)

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -788,8 +788,8 @@ func scanCreateSubCommand(
 		commonParams.Branch, commonParams.BranchFlagUsage,
 	)
 	createScanCmd.PersistentFlags().String(commonParams.SastFilterFlag, "", commonParams.SastFilterUsage)
-	createScanCmd.PersistentFlags().String(commonParams.IacsFilterFlag, "", commonParams.IacsFilterUsage)
-	createScanCmd.PersistentFlags().String(commonParams.KicsFilterFlag, "", commonParams.KicsFilterUsage)
+	createScanCmd.PersistentFlags().StringSlice(commonParams.IacsFilterFlag, []string{}, commonParams.IacsFilterUsage)
+	createScanCmd.PersistentFlags().StringSlice(commonParams.KicsFilterFlag, []string{}, commonParams.KicsFilterUsage)
 
 	err = createScanCmd.PersistentFlags().MarkDeprecated(commonParams.KicsFilterFlag, "please use the replacement flag --iac-security-filter")
 	if err != nil {


### PR DESCRIPTION
## Summary
Converts the `IacsFilterFlag` and `KicsFilterFlag` from String type to StringSlice type to support multiple filter values in IACS and KICS scans.

## Changes
- Changed `IacsFilterFlag` flag definition from `String()` to `StringSlice()`
- Changed `KicsFilterFlag` flag definition from `String()` to `StringSlice()`

## Testing
This change allows users to specify multiple filter values for improved filtering capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)