### PR TITLE
fix: backfill SCA recommendedVersion from ScanReportJson export

### DIFF
--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -1650,6 +1650,7 @@ func enrichScaResults(
 		if scaPackageModel != nil {
 			resultsModel = addPackageInformation(resultsModel, scaPackageModel, scaTypeModel)
 		}
+		backfillRecommendedVersionsFromExport(resultsModel, scaExportDetails.ScaTypes)
 	}
 	if slices.Contains(scan.Engines, commonParams.ContainersType) && !wrappers.IsContainersEnabled {
 		resultsModel = removeResultsByType(resultsModel, commonParams.ContainersType)
@@ -1660,7 +1661,12 @@ func enrichScaResults(
 func parseExportScaVulnerability(types []wrappers.ScaType) *[]wrappers.ScaTypeCollection {
 	var scaTypes []wrappers.ScaTypeCollection
 	for _, t := range types {
-		scaTypes = append(scaTypes, wrappers.ScaTypeCollection(t))
+		scaTypes = append(scaTypes, wrappers.ScaTypeCollection{
+			ID:        t.ID,
+			Type:      t.Type,
+			IsIgnored: t.IsIgnored,
+			PackageID: t.PackageID,
+		})
 	}
 	return &scaTypes
 }
@@ -2877,6 +2883,72 @@ func buildScaState(typesByCVE map[string]wrappers.ScaTypeCollection, result *wra
 
 func buildVulnerabilityIdentifier(result *wrappers.ScanResult) string {
 	return fmt.Sprintf("%s:%s", result.ID, result.ScanResultData.PackageIdentifier)
+}
+
+func scaUpgradeVersionLookupKey(cveID, packageID string) string {
+	return fmt.Sprintf("%s|%s", cveID, packageID)
+}
+
+func buildScaUpgradeVersionLookup(vulnerabilities []wrappers.ScaType) map[string]string {
+	lookup := make(map[string]string)
+	for _, vulnerability := range vulnerabilities {
+		cveID := vulnerability.CveName
+		if cveID == "" {
+			cveID = vulnerability.ID
+		}
+		if cveID == "" || vulnerability.PackageID == "" || vulnerability.NextFixedVersion == "" {
+			continue
+		}
+		lookup[scaUpgradeVersionLookupKey(cveID, vulnerability.PackageID)] = vulnerability.NextFixedVersion
+	}
+	return lookup
+}
+
+func isRecommendedVersionEmpty(version interface{}) bool {
+	if version == nil {
+		return true
+	}
+	value, ok := version.(string)
+	if !ok {
+		return fmt.Sprint(version) == ""
+	}
+	return strings.TrimSpace(value) == ""
+}
+
+func backfillRecommendedVersionsFromExport(
+	resultsModel *wrappers.ScanResultsCollection,
+	vulnerabilities []wrappers.ScaType,
+) {
+	if resultsModel == nil || len(vulnerabilities) == 0 {
+		return
+	}
+
+	lookup := buildScaUpgradeVersionLookup(vulnerabilities)
+	if len(lookup) == 0 {
+		return
+	}
+
+	for _, result := range resultsModel.Results {
+		if result.Type != commonParams.ScaType {
+			continue
+		}
+		if !isRecommendedVersionEmpty(result.ScanResultData.RecommendedVersion) {
+			continue
+		}
+
+		cveID := result.ID
+		if cveID == "" {
+			cveID = result.VulnerabilityDetails.CveName
+		}
+		packageID := result.ScanResultData.PackageIdentifier
+		if cveID == "" || packageID == "" {
+			continue
+		}
+
+		if version, ok := lookup[scaUpgradeVersionLookupKey(cveID, packageID)]; ok {
+			result.ScanResultData.RecommendedVersion = version
+		}
+	}
 }
 
 func addPackageInformation(

--- a/internal/commands/result_test.go
+++ b/internal/commands/result_test.go
@@ -1045,6 +1045,58 @@ func Test_addPackageInformation(t *testing.T) {
 	assert.Equal(t, expectedFixLink, actualFixLink, "FixLink should match the result ID")
 }
 
+func Test_backfillRecommendedVersionsFromExport(t *testing.T) {
+	resultsModel := &wrappers.ScanResultsCollection{
+		Results: []*wrappers.ScanResult{
+			{
+				Type: "sca",
+				ID:   "CVE-2024-0001",
+				ScanResultData: wrappers.ScanResultData{
+					PackageIdentifier:  "pkg-empty",
+					RecommendedVersion: "",
+				},
+			},
+			{
+				Type: "sca",
+				ID:   "CVE-2024-0002",
+				ScanResultData: wrappers.ScanResultData{
+					PackageIdentifier:  "pkg-existing",
+					RecommendedVersion: "1.2.3",
+				},
+			},
+		},
+	}
+	exportVulnerabilities := []wrappers.ScaType{
+		{
+			CveName:          "CVE-2024-0001",
+			PackageID:        "pkg-empty",
+			NextFixedVersion: "4.5.6",
+		},
+		{
+			CveName:          "CVE-2024-0002",
+			PackageID:        "pkg-existing",
+			NextFixedVersion: "9.9.9",
+		},
+	}
+
+	backfillRecommendedVersionsFromExport(resultsModel, exportVulnerabilities)
+
+	assert.Equal(t, "4.5.6", resultsModel.Results[0].ScanResultData.RecommendedVersion)
+	assert.Equal(t, "1.2.3", resultsModel.Results[1].ScanResultData.RecommendedVersion)
+}
+
+func Test_buildScaUpgradeVersionLookup_usesCveIDFallback(t *testing.T) {
+	lookup := buildScaUpgradeVersionLookup([]wrappers.ScaType{
+		{
+			ID:               "CVE-2024-9999",
+			PackageID:        "pkg-1",
+			NextFixedVersion: "2.0.0",
+		},
+	})
+
+	assert.Equal(t, "2.0.0", lookup["CVE-2024-9999|pkg-1"])
+}
+
 func TestRunGetResultsByScanIdGLSastFormat_NoVulnerabilities_Success(t *testing.T) {
 	// Execute the command and perform nil assertion
 	execCmdNilAssertion(t, "results", "show", "--scan-id", "MOCK_NO_VULNERABILITIES", "--report-format", "gl-sast")

--- a/internal/wrappers/export.go
+++ b/internal/wrappers/export.go
@@ -36,8 +36,10 @@ type PackagePath struct {
 }
 
 type ScaType struct {
-	ID        string `json:"Id,omitempty"`
-	Type      string `json:"Type,omitempty"`
-	IsIgnored bool   `json:"IsIgnored,omitempty"`
-	PackageID string `json:"PackageID,omitempty"`
+	ID               string `json:"Id,omitempty"`
+	CveName          string `json:"CveName,omitempty"`
+	Type             string `json:"Type,omitempty"`
+	IsIgnored        bool   `json:"IsIgnored,omitempty"`
+	PackageID        string `json:"PackageID,omitempty"`
+	NextFixedVersion string `json:"NextFixedVersion,omitempty"`
 }


### PR DESCRIPTION
**By submitting this pull request, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please review the [contributing guidelines](../docs/contributing.md) for guidance on creating high-quality pull requests.**

## Description

## Summary

SCA findings in JSON scan reports (`cx_result.json`) often have an empty `data.recommendedVersion` even though the ScanReportJson export already contains a per-CVE fix version (`NextFixedVersion`).

The CLI already downloads ScanReportJson during result enrichment (`ReadResults` → `enrichScaResults` → `GetExportPackage`) and uses it to populate package metadata (`scaPackageData`, dependency paths, `fixLink`). However, `recommendedVersion` was only passed through from the Results API and was never backfilled from the export.

This change fills `data.recommendedVersion` from export data when the Results API value is empty, using a `{CveName|PackageID}` lookup keyed to `NextFixedVersion`.

## Problem

- `recommendedVersion` in JSON output comes from the paginated Results API response.
- For many SCA findings (including transitive dependencies and per-CVE remediation cases), the API returns an empty string.
- The CLI already fetches ScanReportJson export but previously parsed only a subset of vulnerability fields (`Id`, `Type`, `IsIgnored`, `PackageID`) and ignored `NextFixedVersion`.
- Downstream consumers (CI/CD integrations, SAR/SCA tooling) rely on `recommendedVersion` for upgrade/remediation guidance.

## Solution

1. Extend export `ScaType` to parse `CveName` and `NextFixedVersion` from ScanReportJson `Vulnerabilities`.
2. After existing SCA package enrichment, backfill empty `data.recommendedVersion` values from export using lookup key `{CveName|PackageID}` (falls back to `Id` when `CveName` is absent).
3. Do not overwrite non-empty `recommendedVersion` values returned by the Results API.

## Files changed

- `internal/wrappers/export.go` — add export vulnerability fields
- `internal/commands/result.go` — backfill logic in `enrichScaResults`
- `internal/commands/result_test.go` — unit tests for lookup and backfill behavior

## Test plan

- [x] `go test ./internal/commands/ -run 'Test_backfillRecommendedVersionsFromExport|Test_buildScaUpgradeVersionLookup|Test_addPackageInformation'`
- [ ] Run `cx scan create --report-format json` on a repo with SCA findings where Results API returns empty `recommendedVersion`
- [ ] Verify `cx_result.json` now contains `data.recommendedVersion` populated from export where available
- [ ] Verify findings that already had `recommendedVersion` from the API are unchanged

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

*Link any related issues or tickets.*

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable)
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used

## Screenshots (if applicable)

*Add screenshots to help explain your changes.*

## Additional Notes

*Add any other relevant information.*
