### PR TITLE
AST-172563 Use Docker Hub OIDC federation in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,10 +135,11 @@ jobs:
           docker info
       - name: Login to Docker Hub
         if: inputs.dev == false
-        uses: step-security/docker-login-action@870af644803bf9f204aed474adbad2958fec048b # v4.1.0
+        uses: step-security/docker-login-action@bd6978fd4ef9a5f78130095b298b8a721afcb0d8 # v4.5.1
         with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
 
       - name: Install Cosign
         if: inputs.dev == false


### PR DESCRIPTION
Login to Docker Hub in the release workflow used a static username/password pair, via docker-login-action v4.1.0 which predates OIDC support.
