### PR TITLE
Align empty-tar container tests with Cx-One scan create (AST-176917)

### DIFF
--- a/test/integration/container_images_validation_test.go
+++ b/test/integration/container_images_validation_test.go
@@ -186,8 +186,9 @@ func TestContainerImageValidation_TarFiles(t *testing.T) {
 	tempDir := t.TempDir()
 	emptyTarFile := filepath.Join(tempDir, "test-image.tar")
 
-	// Create an empty .tar file for testing
-	// Note: An empty tar file is NOT a valid container image, so it should fail during processing
+	// Create an empty .tar file for testing.
+	// Flag validation only checks that the .tar exists. Local resolution records it as
+	// Status=Failed in containers-resolution.json and continues; scan create still succeeds.
 	f, err := os.Create(emptyTarFile)
 	assert.NilError(t, err, "Should create temp .tar file")
 	f.Close()
@@ -201,8 +202,8 @@ func TestContainerImageValidation_TarFiles(t *testing.T) {
 		{
 			name:          "EmptyTarFile",
 			tarFile:       emptyTarFile,
-			shouldSucceed: false,
-			description:   "Empty .tar file should fail during container resolution (not a valid container image)",
+			shouldSucceed: true,
+			description:   "Empty .tar file is recorded as unresolved and scan create still succeeds",
 		},
 		{
 			name:          "NonExistentTarFile",
@@ -239,8 +240,7 @@ func TestContainerImageValidation_TarFiles(t *testing.T) {
 
 // TestContainerImageValidation_MixedTarAndRegularImages tests mixing .tar files with regular images
 func TestContainerImageValidation_MixedTarAndRegularImages(t *testing.T) {
-	// Create a temporary .tar file for testing
-	// Note: An empty tar file is NOT a valid container image
+	// Empty tar is not a container image; mixed with a valid image it must not abort scan create.
 	tempDir := t.TempDir()
 	emptyTarFile := filepath.Join(tempDir, "test-image.tar")
 
@@ -249,7 +249,7 @@ func TestContainerImageValidation_MixedTarAndRegularImages(t *testing.T) {
 	f.Close()
 
 	t.Run("EmptyTarAndRegularImage", func(t *testing.T) {
-		// Empty tar file should fail during container resolution
+		// Valid images are still resolved; the empty tar is recorded as Failed and does not abort scan create.
 		createASTIntegrationTestCommand(t)
 		imageList := fmt.Sprintf("nginx:alpine,%s", emptyTarFile)
 		testArgs := []string{
@@ -261,8 +261,9 @@ func TestContainerImageValidation_MixedTarAndRegularImages(t *testing.T) {
 			flag(params.ScanTypes), params.ContainersTypeFlag,
 			flag(params.ScanInfoFormatFlag), printer.FormatJSON,
 		}
-		err, _ := executeCommand(t, testArgs...)
-		assert.Assert(t, err != nil, "Expected error for empty tar file mixed with valid images")
+		scanID, projectID := executeCreateScan(t, testArgs)
+		assert.Assert(t, scanID != "", "Scan ID should not be empty when mixing a valid image with an empty tar")
+		assert.Assert(t, projectID != "", "Project ID should not be empty when mixing a valid image with an empty tar")
 	})
 
 	t.Run("EmptyTarAndInvalidRegularImage", func(t *testing.T) {

--- a/test/integration/container_scan_edge_cases_test.go
+++ b/test/integration/container_scan_edge_cases_test.go
@@ -50,8 +50,7 @@ func TestContainerScan_TarFileValidation(t *testing.T) {
 	tempDir := t.TempDir()
 
 	t.Run("EmptyTarFile", func(t *testing.T) {
-		// Create an empty .tar file
-		// Note: An empty tar file is NOT a valid container image, so container resolution will fail
+		// Empty tar is not a container image; local resolution records Status=Failed and scan create still succeeds.
 		tarFile := filepath.Join(tempDir, "test-container.tar")
 		f, err := os.Create(tarFile)
 		assert.NilError(t, err)
@@ -67,8 +66,9 @@ func TestContainerScan_TarFileValidation(t *testing.T) {
 			flag(params.ScanTypes), params.ContainersTypeFlag,
 			flag(params.ScanInfoFormatFlag), printer.FormatJSON,
 		}
-		err, _ = executeCommand(t, testArgs...)
-		assert.Assert(t, err != nil, "Expected error for empty tar file (not a valid container image)")
+		scanID, projectID := executeCreateScan(t, testArgs)
+		assert.Assert(t, scanID != "", "Scan ID should not be empty for empty tar file")
+		assert.Assert(t, projectID != "", "Project ID should not be empty for empty tar file")
 	})
 
 	t.Run("NonExistentTarFile", func(t *testing.T) {
@@ -88,8 +88,7 @@ func TestContainerScan_TarFileValidation(t *testing.T) {
 	})
 
 	t.Run("EmptyTarFileWithOtherImages", func(t *testing.T) {
-		// Create an empty .tar file
-		// Note: An empty tar file is NOT a valid container image, so container resolution will fail
+		// nginx:alpine is resolved; the empty tar is recorded as Failed and does not abort scan create.
 		tarFile := filepath.Join(tempDir, "another-test.tar")
 		f, err := os.Create(tarFile)
 		assert.NilError(t, err)
@@ -105,8 +104,9 @@ func TestContainerScan_TarFileValidation(t *testing.T) {
 			flag(params.ScanTypes), params.ContainersTypeFlag,
 			flag(params.ScanInfoFormatFlag), printer.FormatJSON,
 		}
-		err, _ = executeCommand(t, testArgs...)
-		assert.Assert(t, err != nil, "Expected error for empty tar file mixed with other images")
+		scanID, projectID := executeCreateScan(t, testArgs)
+		assert.Assert(t, scanID != "", "Scan ID should not be empty when mixing a valid image with an empty tar")
+		assert.Assert(t, projectID != "", "Project ID should not be empty when mixing a valid image with an empty tar")
 	})
 }
 


### PR DESCRIPTION
Container integration tests have been failing since ~20 Aug 2026 because four empty-`.tar` cases still expected `scan create` to error.

ast-cli never aborted on empty tar. Local resolution records `status: Failed` and continues. What changed is Checkmarx One accepting that scan (empty / Failed-only resolution zip) instead of failing after upload. Last green Container Tests: 19 Aug ~11:18 UTC. First red: 20 Aug ~08:43 UTC. No CLI resolver change in that window.

This PR updates those four assertions to expect a scan ID. Missing `.tar` and invalid `image:tag` still fail.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Additional Notes

Coverage 68% vs 75% is a separate repo-wide gate. This PR does not change production CLI code.

Local check: `TestContainerImageValidation_TarFiles` against the integration tenant; empty tar created a scan (containers Completed, 0 findings); missing tar still erred.