### PR TITLE
AST-171789 Force removal of broken Homebrew tap and verify it succeeded

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,14 @@ jobs:
           echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
       - name: Remove broken Homebrew tap before Docker setup
         if: inputs.dev == false
-        run: brew untap hashicorp/tap || true
+        run: |
+          set -euo pipefail
+          brew untap --force hashicorp/tap || true
+          if [ -d "$(brew --repo hashicorp/tap)" ]; then
+            echo "ERROR: hashicorp/tap is still present after untap"
+            exit 1
+          fi
+          brew tap
       - name: Setup Docker on macOS
         if: inputs.dev == false
         uses: douglascamata/setup-docker-macos-action@5643cfd7e434881308f89f2f3ae8852da11df909


### PR DESCRIPTION
Homebrew was refusing to remove the hashicorp/tap while a formula from it was still installed, and the untap step swallowed that failure with `|| true`, so it passed while leaving the tap in place and the release failed later at Docker setup.

This forces the untap and then verifies the tap directory is actually gone, failing the step loudly if not. It's a workaround for the stale tap baked into the shared macOS runner image.
