### PR TITLE
AST-171789 Remove non-essential Homebrew taps before macOS Docker setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,15 +119,27 @@ jobs:
         id: arch
         run: |
           echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
-      - name: Remove broken Homebrew tap before Docker setup
+      - name: Remove non-essential Homebrew taps before Docker setup
         if: inputs.dev == false
         run: |
           set -euo pipefail
-          brew untap --force hashicorp/tap || true
-          if [ -d "$(brew --repo hashicorp/tap)" ]; then
-            echo "ERROR: hashicorp/tap is still present after untap"
-            exit 1
-          fi
+          # Homebrew >=6.0.13 disabled `depends_on macos: <symbol>`; stale third-party
+          # taps on the shared runner still use it and abort the `brew update` that the
+          # Docker setup action runs internally. Keep only the taps this build needs:
+          # homebrew/core + homebrew/cask (base), bearer/tap (provides gon, used for
+          # Apple notarization).
+          KEEP="homebrew/core homebrew/cask bearer/tap"
+          for tap in $(brew tap); do
+            case " ${KEEP} " in
+              *" ${tap} "*) echo "Keeping ${tap}"; continue ;;
+            esac
+            echo "Untapping ${tap}"
+            brew untap --force "${tap}" || true
+            if [ -d "$(brew --repo "${tap}")" ]; then
+              echo "ERROR: ${tap} is still present after untap"
+              exit 1
+            fi
+          done
           brew tap
       - name: Setup Docker on macOS
         if: inputs.dev == false


### PR DESCRIPTION
The macOS Docker setup step runs a Homebrew update internally, and stale third-party taps on the shared runner image use a formula directive recent Homebrew versions removed, which aborts the update and fails the release.

Removing one offending tap was not enough; another tap hit the same issue. This swaps the single-tap removal for an allowlist so any current or future stale tap gets removed, keeping only the base taps plus the one providing the notarization tool.

Each removal is verified so a failure cannot pass silently. This is a workaround for the runner image and should go away once that image is fixed.