### PR TITLE
AST-171789 Clear Homebrew casks before macOS Docker setup in release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,32 @@ jobs:
             fi
           done
           brew tap
+      - name: Remove installed Homebrew casks before Docker setup
+        if: inputs.dev == false
+        run: |
+          set -uo pipefail
+          # Stale casks baked into the runner image still use the `depends_on macos:`
+          # DSL that Homebrew >=6.0.13 disabled, so evaluating them aborts the `brew
+          # update` the Docker setup action runs internally. This release job uses no
+          # cask, so empty the Caskroom before that step runs.
+          CASKROOM="$(brew --caskroom)"
+          for cask in $(brew list --cask 2>/dev/null); do
+            echo "Uninstalling cask ${cask}"
+            brew uninstall --cask --force "${cask}" || echo "WARNING: brew uninstall --cask ${cask} failed"
+          done
+          if [ -d "${CASKROOM}" ]; then
+            for leftover in "${CASKROOM}"/*; do
+              [ -e "${leftover}" ] || continue
+              echo "Removing leftover Caskroom entry ${leftover}"
+              rm -rf "${leftover}"
+            done
+          fi
+          remaining="$(brew list --cask 2>/dev/null)"
+          if [ -n "${remaining}" ]; then
+            echo "ERROR: casks still installed after cleanup: ${remaining}"
+            exit 1
+          fi
+          echo "Caskroom is empty"
       - name: Setup Docker on macOS
         if: inputs.dev == false
         uses: douglascamata/setup-docker-macos-action@5643cfd7e434881308f89f2f3ae8852da11df909


### PR DESCRIPTION
The macOS release job fails at Setup Docker on macOS, which internally runs `brew update`. That self-updates Homebrew to a version that dropped the legacy `depends_on macos:` DSL, and evaluating stale cask definitions baked into the runner image then aborts `brew update` after its real work is done. This job installs no casks, so we clear the Caskroom before that step runs. Earlier attempts (#1558-#1560) targeted Homebrew taps, the wrong axis — the failure reproduces identically with or without tap cleanup.

This can't be reproduced or proven locally; a maintainer should trigger the release workflow on the macOS runner to confirm.
