### PR TITLE
AST-171789 Replace macOS Docker setup action to avoid Homebrew update failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,57 +119,11 @@ jobs:
         id: arch
         run: |
           echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
-      - name: Remove non-essential Homebrew taps before Docker setup
-        if: inputs.dev == false
-        run: |
-          set -euo pipefail
-          # Homebrew >=6.0.13 disabled `depends_on macos: <symbol>`; stale third-party
-          # taps on the shared runner still use it and abort the `brew update` that the
-          # Docker setup action runs internally. Keep only the taps this build needs:
-          # homebrew/core + homebrew/cask (base), bearer/tap (provides gon, used for
-          # Apple notarization).
-          KEEP="homebrew/core homebrew/cask bearer/tap"
-          for tap in $(brew tap); do
-            case " ${KEEP} " in
-              *" ${tap} "*) echo "Keeping ${tap}"; continue ;;
-            esac
-            echo "Untapping ${tap}"
-            brew untap --force "${tap}" || true
-            if [ -d "$(brew --repo "${tap}")" ]; then
-              echo "ERROR: ${tap} is still present after untap"
-              exit 1
-            fi
-          done
-          brew tap
-      - name: Remove installed Homebrew casks before Docker setup
-        if: inputs.dev == false
-        run: |
-          set -uo pipefail
-          # Stale casks baked into the runner image still use the `depends_on macos:`
-          # DSL that Homebrew >=6.0.13 disabled, so evaluating them aborts the `brew
-          # update` the Docker setup action runs internally. This release job uses no
-          # cask, so empty the Caskroom before that step runs.
-          CASKROOM="$(brew --caskroom)"
-          for cask in $(brew list --cask 2>/dev/null); do
-            echo "Uninstalling cask ${cask}"
-            brew uninstall --cask --force "${cask}" || echo "WARNING: brew uninstall --cask ${cask} failed"
-          done
-          if [ -d "${CASKROOM}" ]; then
-            for leftover in "${CASKROOM}"/*; do
-              [ -e "${leftover}" ] || continue
-              echo "Removing leftover Caskroom entry ${leftover}"
-              rm -rf "${leftover}"
-            done
-          fi
-          remaining="$(brew list --cask 2>/dev/null)"
-          if [ -n "${remaining}" ]; then
-            echo "ERROR: casks still installed after cleanup: ${remaining}"
-            exit 1
-          fi
-          echo "Caskroom is empty"
       - name: Setup Docker on macOS
         if: inputs.dev == false
-        uses: douglascamata/setup-docker-macos-action@5643cfd7e434881308f89f2f3ae8852da11df909
+        uses: step-security/actions-setup-docker@168b7380ee5a2292e33809debdb941da6df3ff77 # v1.0.12
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
       - name: Test docker
         if: inputs.dev == false
         run: |


### PR DESCRIPTION
The macOS release job kept failing in the Docker setup step because that action runs a Homebrew update internally, and a stale formula on the shared runner image uses a directive recent Homebrew removed, aborting the update. Removing offending taps and casks didn't fix it and the actual bad formula was never identified, so this swaps in a StepSecurity-maintained action that installs Docker from a pinned cask and never runs a Homebrew update, making the failure unreachable. The two earlier cleanup workarounds are dropped since they mutated shared runner state and no longer serve a purpose. Also sets `HOMEBREW_NO_AUTO_UPDATE=1` as a belt-and-suspenders guard.
