### PR TITLE
AST-171789 Remove Homebrew downgrade so Docker client install can resolve bottles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,15 +103,11 @@ jobs:
           p12-file-base64: ${{ env.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           # The password used to import the PKCS12 file.
           p12-password: ${{ env.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
-      - name: Updating and upgrading brew to a specific version
-        run: |
-          brew --version
-          cd $(brew --repo)
-          git fetch --tags
-          git checkout 4.4.15
-          export HOMEBREW_NO_AUTO_UPDATE=1
-          brew --version
       - name: Install gon
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_UPGRADE: "1"
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
         run: |
           brew install Bearer/tap/gon
       # New: detect architecture and expose as step output


### PR DESCRIPTION
The release job pinned Homebrew to 4.4.15. That downgrade used to be undone immediately by the Docker setup action's Homebrew update, so it never really took effect. Now that those update calls are gone, the downgrade persists and Homebrew is too old to resolve current formulae, breaking the Docker client install.

This removes the downgrade so Homebrew stays at the runner image's version, and adds the same no-auto-update guards to the gon install step that the Docker client install already had.
